### PR TITLE
C++ compatibility and fix compiler warnings

### DIFF
--- a/demo/common/nuklear_gamepad_demo.c
+++ b/demo/common/nuklear_gamepad_demo.c
@@ -35,8 +35,7 @@ void nuklear_gamepad_demo(struct nk_context* ctx, struct nk_gamepads* gamepads) 
             WINDOW_WIDTH / 2, WINDOW_HEIGHT / 2 - padding * 2);
 
         // Make a window for each controller
-        const char* title = nk_gamepad_name(gamepads, i);
-        if (nk_begin_titled(ctx, name, title ? title : "UNKNOWN", window_bounds,
+        if (nk_begin_titled(ctx, name, nk_gamepad_name(gamepads, i), window_bounds,
             NK_WINDOW_BORDER | NK_WINDOW_TITLE | NK_WINDOW_MOVABLE | NK_WINDOW_MINIMIZABLE))
         {
             nk_layout_row_dynamic(ctx, 0, 7);

--- a/demo/common/nuklear_gamepad_demo.c
+++ b/demo/common/nuklear_gamepad_demo.c
@@ -35,7 +35,8 @@ void nuklear_gamepad_demo(struct nk_context* ctx, struct nk_gamepads* gamepads) 
             WINDOW_WIDTH / 2, WINDOW_HEIGHT / 2 - padding * 2);
 
         // Make a window for each controller
-        if (nk_begin_titled(ctx, name, nk_gamepad_name(gamepads, i), window_bounds,
+        const char* title = nk_gamepad_name(gamepads, i);
+        if (nk_begin_titled(ctx, name, title ? title : "UNKNOWN", window_bounds,
             NK_WINDOW_BORDER | NK_WINDOW_TITLE | NK_WINDOW_MOVABLE | NK_WINDOW_MINIMIZABLE))
         {
             nk_layout_row_dynamic(ctx, 0, 7);

--- a/demo/sdl/main.c
+++ b/demo/sdl/main.c
@@ -33,6 +33,8 @@
 #include "../common/nuklear_gamepad_demo.c"
 
 int main(int argc, char *argv[]) {
+    NK_UNUSED(argc);
+    NK_UNUSED(argv);
     /* Platform */
     SDL_Window *win;
     SDL_Renderer *renderer;

--- a/nuklear_gamepad.h
+++ b/nuklear_gamepad.h
@@ -27,6 +27,10 @@
 #ifndef NUKLEAR_GAMEPAD_H__
 #define NUKLEAR_GAMEPAD_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum nk_gamepad_button {
     NK_GAMEPAD_BUTTON_UP,
     NK_GAMEPAD_BUTTON_DOWN,
@@ -60,6 +64,7 @@ struct nk_gamepads {
 NK_API struct nk_gamepads* nk_gamepad_init(struct nk_context* ctx, void* user_data);
 NK_API void nk_gamepad_free(struct nk_gamepads* gamepads);
 NK_API void nk_gamepad_init_gamepads(struct nk_gamepads* gamepads, int num);
+NK_API void nk_gamepad_update(struct nk_gamepads* gamepads);
 NK_API nk_bool nk_gamepad_is_button_down(struct nk_gamepads* gamepads, int num, enum nk_gamepad_button button);
 NK_API nk_bool nk_gamepad_is_button_pressed(struct nk_gamepads* gamepads, int num, enum nk_gamepad_button button);
 NK_API nk_bool nk_gamepad_is_button_released(struct nk_gamepads* gamepads, int num, enum nk_gamepad_button button);
@@ -68,6 +73,10 @@ NK_API int nk_gamepad_count(struct nk_gamepads* gamepads);
 NK_API const char* nk_gamepad_name(struct nk_gamepads* gamepads, int num);
 
 #define NK_GAMEPAD_BUTTON_FLAG(button) (1 << (button))
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/nuklear_gamepad_sdl.h
+++ b/nuklear_gamepad_sdl.h
@@ -36,6 +36,7 @@ NK_API void nk_gamepad_sdl_init(struct nk_gamepads* gamepads) {
     if (gamepads->gamepads != NULL) {
         nk_gamepad_sdl_free(gamepads);
         nk_handle unused;
+        NK_UNUSED(unused);
         NK_GAMEPAD_MFREE(unused, gamepads->gamepads);
         gamepads->gamepads = NULL;
         gamepads->gamepads_count = 0;

--- a/nuklear_gamepad_sdl.h
+++ b/nuklear_gamepad_sdl.h
@@ -105,7 +105,7 @@ NK_API const char* nk_gamepad_sdl_name(struct nk_gamepads* gamepads, int num) {
 
     SDL_GameController* controller = gamepads->gamepads[num].data;
     if (!controller) {
-        return NULL;
+        return gamepads->gamepads[num].name;
     }
 
     const char* name = SDL_GameControllerName(controller);


### PR DESCRIPTION
1. Add extern "C" when compiling from C++
2. Forward declare nk_gamepad_update
3. Sprinkle some NK_UNUSED macros on unused variables
4. Return generic controller name if SDL_GameController is NULL (ex. joystick that's not also an SDL_GameController)

These changes allow the code to compile with -Wall -Wextra -Werror on gcc/g++ 12.3.0