### PR TITLE
Add XInput platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Gamepad API for [Nuklear](https://github.com/Immediate-Mode-UI/Nuklear).
 //#define NK_GAMEPAD_RAYLIB
 //#define NK_GAMEPAD_PNTR
 //#define NK_GAMEPAD_KEYBOARD
+//#define NK_GAMEPAD_XINPUT
 //#define NK_GAMEPAD_NONE
 #include "nuklear_gamepad.h"
 
@@ -36,6 +37,7 @@ nk_gamepad_free(&gamepads);
 - [GLFW](https://www.glfw.org/)
 - [raylib](https://www.raylib.com/)
 - [pntr](https://github.com/robloach/pntr) with [pntr_app](https://github.com/robloach/pntr_app)
+- [XInput](https://learn.microsoft.com/en-us/windows/win32/xinput/getting-started-with-xinput) (Windows)
 - [Custom](#custom-integration)
 - [Add more!](https://github.com/RobLoach/nuklear_gamepad/issues)
 

--- a/demo/xinput/Makefile
+++ b/demo/xinput/Makefile
@@ -1,0 +1,22 @@
+BIN = nuklear_gamepad_demo_xinput
+
+CFLAGS += -std=c89 -Wall -Wextra -pedantic -O2
+
+SRC = main.c
+OBJ = $(SRC:.c=.o)
+
+ifeq ($(OS),Windows_NT)
+BIN := $(BIN).exe
+LIBS = -lglfw3 -lopengl32 -lm -lGLU32 -lGLEW32 -lxinput
+else
+$(error XInput is only supported on Windows)
+endif
+
+$(BIN): clean
+	$(CC) $(SRC) $(CFLAGS) -o $(BIN) $(LIBS)
+
+clean:
+	rm -f $(BIN) $(OBJS)
+
+test: clean $(BIN)
+	./$(BIN)

--- a/demo/xinput/main.c
+++ b/demo/xinput/main.c
@@ -1,0 +1,111 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <string.h>
+#include <math.h>
+#include <assert.h>
+#include <limits.h>
+#include <time.h>
+
+#include <GL/glew.h>
+#include <GLFW/glfw3.h>
+
+#define NK_INCLUDE_FIXED_TYPES
+#define NK_INCLUDE_STANDARD_IO
+#define NK_INCLUDE_STANDARD_VARARGS
+#define NK_INCLUDE_DEFAULT_ALLOCATOR
+#define NK_INCLUDE_VERTEX_BUFFER_OUTPUT
+#define NK_INCLUDE_FONT_BAKING
+#define NK_INCLUDE_DEFAULT_FONT
+#define NK_IMPLEMENTATION
+#define NK_GLFW_GL3_IMPLEMENTATION
+#define NK_KEYSTATE_BASED_INPUT
+#include "../../vendor/nuklear/nuklear.h"
+#include "../../vendor/nuklear/demo/glfw_opengl3/nuklear_glfw_gl3.h"
+
+#define NK_GAMEPAD_XINPUT
+#define NK_GAMEPAD_KEYBOARD
+#define NK_GAMEPAD_IMPLEMENTATION
+#include "../../nuklear_gamepad.h"
+
+#define WINDOW_WIDTH 800
+#define WINDOW_HEIGHT 600
+
+#define MAX_VERTEX_BUFFER 512 * 1024
+#define MAX_ELEMENT_BUFFER 128 * 1024
+
+#include "../common/nuklear_gamepad_demo.c"
+
+static void error_callback(int e, const char *d)
+{printf("Error %d: %s\n", e, d);}
+
+int main(void)
+{
+    struct nk_glfw glfw = {0};
+    static GLFWwindow *win;
+    int width = 0, height = 0;
+    struct nk_context *ctx;
+    struct nk_gamepads gamepads;
+    float font_scale = 2;
+
+    glfwSetErrorCallback(error_callback);
+    if (!glfwInit()) {
+        fprintf(stdout, "[GFLW] failed to init!\n");
+        exit(1);
+    }
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+#ifdef __APPLE__
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+#endif
+    win = glfwCreateWindow(WINDOW_WIDTH, WINDOW_HEIGHT, "nuklear_gamepad [xinput]", NULL, NULL);
+    glfwMakeContextCurrent(win);
+    glfwGetWindowSize(win, &width, &height);
+
+    glViewport(0, 0, WINDOW_WIDTH, WINDOW_HEIGHT);
+    glewExperimental = 1;
+    if (glewInit() != GLEW_OK) {
+        fprintf(stderr, "Failed to setup GLEW\n");
+        exit(1);
+    }
+
+    ctx = nk_glfw3_init(&glfw, win, NK_GLFW3_INSTALL_CALLBACKS);
+    {
+        struct nk_font_atlas *atlas;
+        struct nk_font_config config;
+        struct nk_font *font;
+        nk_glfw3_font_stash_begin(&glfw, &atlas);
+        config = nk_font_config(0);
+        font = nk_font_atlas_add_default(atlas, 13 * font_scale, &config);
+        nk_glfw3_font_stash_end(&glfw);
+        nk_style_set_font(ctx, &font->handle);
+    }
+
+    nk_gamepad_init(&gamepads, ctx, NULL);
+
+    while (!glfwWindowShouldClose(win))
+    {
+        glfwPollEvents();
+
+        nk_gamepad_update(&gamepads);
+
+        nk_glfw3_new_frame(&glfw);
+
+        nuklear_gamepad_demo(ctx, &gamepads, NULL);
+
+        glfwGetWindowSize(win, &width, &height);
+        glViewport(0, 0, width, height);
+        glClear(GL_COLOR_BUFFER_BIT);
+        glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+        nk_glfw3_render(&glfw, NK_ANTI_ALIASING_ON, MAX_VERTEX_BUFFER, MAX_ELEMENT_BUFFER);
+        glfwSwapBuffers(win);
+    }
+
+    nk_gamepad_free(&gamepads);
+
+    nk_glfw3_shutdown(&glfw);
+    glfwTerminate();
+    return 0;
+}

--- a/nuklear_gamepad.h
+++ b/nuklear_gamepad.h
@@ -64,6 +64,7 @@ enum nk_gamepad_input_source_type {
     NK_GAMEPAD_INPUT_SOURCE_KEYBOARD, /* A gamepad input source which uses nuklear's keyboard interface to retrieve its input. @see nuklear_gamepad_keyboard_input_source() */
     NK_GAMEPAD_INPUT_SOURCE_SDL3, /* A gamepad input source which uses SDL3 to retrieve its input. @see nk_gamepad_sdl3_input_source() */
     NK_GAMEPAD_INPUT_SOURCE_MOUSE, /* A gamepad input source which uses nuklear's mouse interface to retrieve its input. @see nk_gamepad_mouse_input_source() */
+    NK_GAMEPAD_INPUT_SOURCE_XINPUT, /* A gamepad input source which uses XInput to retrieve its input. @see nk_gamepad_xinput_input_source() */
     NK_GAMEPAD_INPUT_SOURCE_LAST
 };
 
@@ -421,6 +422,7 @@ NK_API nk_gamepad_input_source_fn nk_gamepad_input_sources[];
     !defined(NK_GAMEPAD_RAYLIB) && \
     !defined(NK_GAMEPAD_PNTR) && \
     !defined(NK_GAMEPAD_KEYBOARD) && \
+    !defined(NK_GAMEPAD_XINPUT) && \
     !defined(NK_GAMEPAD_NONE)
     #if defined(NK_SDL_RENDERER_IMPLEMENTATION) || defined(NK_SDL_GL2_IMPLEMENTATION) || defined(NK_SDL_GL3_IMPLEMENTATION) || defined(NK_SDL_GLES2_IMPLEMENTATION)
         #define NK_GAMEPAD_SDL
@@ -432,6 +434,8 @@ NK_API nk_gamepad_input_source_fn nk_gamepad_input_sources[];
         #define NK_GAMEPAD_RAYLIB
     #elif defined(PNTR_NUKLEAR_IMPLEMENTATION)
         #define NK_GAMEPAD_PNTR
+    #elif defined(_WIN32) && defined(XINPUT_GAMEPAD_A)
+        #define NK_GAMEPAD_XINPUT
     #endif
 #endif
 
@@ -456,6 +460,9 @@ NK_API nk_gamepad_input_source_fn nk_gamepad_input_sources[];
 #endif
 #ifdef NK_GAMEPAD_MOUSE
 #include "nuklear_gamepad_mouse.h"
+#endif
+#ifdef NK_GAMEPAD_XINPUT
+#include "nuklear_gamepad_xinput.h"
 #endif
 
 /* Gamepad Source: None - Always available */
@@ -482,6 +489,9 @@ nk_gamepad_input_source_fn nk_gamepad_input_sources[] = {
 #endif
 #ifdef NK_GAMEPAD_MOUSE
     &nk_gamepad_mouse_input_source,
+#endif
+#ifdef NK_GAMEPAD_XINPUT
+    &nk_gamepad_xinput_input_source,
 #endif
 
     /* Dummy Gamepad Source */

--- a/nuklear_gamepad_xinput.h
+++ b/nuklear_gamepad_xinput.h
@@ -1,0 +1,124 @@
+#ifndef NUKLEAR_GAMEPAD_XINPUT_H__
+#define NUKLEAR_GAMEPAD_XINPUT_H__
+
+#if !defined(NK_GAMEPAD_MAX) && defined(XUSER_MAX_COUNT)
+#define NK_GAMEPAD_MAX XUSER_MAX_COUNT
+#elif !defined(NK_GAMEPAD_MAX)
+#define NK_GAMEPAD_MAX 4
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NK_API nk_bool nk_gamepad_xinput_init(struct nk_gamepads* gamepads, void* user_data);
+NK_API void nk_gamepad_xinput_update(struct nk_gamepads* gamepads, void* user_data);
+NK_API const char* nk_gamepad_xinput_name(struct nk_gamepads* gamepads, int num, void* user_data);
+NK_API struct nk_gamepad_input_source nk_gamepad_xinput_input_source(void* user_data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+#if defined(NK_GAMEPAD_IMPLEMENTATION) && !defined(NK_GAMEPAD_HEADER_ONLY)
+#ifndef NUKLEAR_GAMEPAD_XINPUT_IMPLEMENTATION_ONCE
+#define NUKLEAR_GAMEPAD_XINPUT_IMPLEMENTATION_ONCE
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NK_API nk_bool nk_gamepad_xinput_init(struct nk_gamepads* gamepads, void* user_data) {
+    int i;
+    NK_UNUSED(user_data);
+    if (gamepads == NULL) {
+        return nk_false;
+    }
+    for (i = 0; i < NK_GAMEPAD_MAX; i++) {
+        XINPUT_STATE state;
+        gamepads->gamepads[i].available = (XInputGetState(i, &state) == ERROR_SUCCESS) ? nk_true : nk_false;
+    }
+    return nk_true;
+}
+
+NK_API void nk_gamepad_xinput_update(struct nk_gamepads* gamepads, void* user_data) {
+    int num;
+    NK_UNUSED(user_data);
+    if (gamepads == NULL) {
+        return;
+    }
+
+    for (num = 0; num < NK_GAMEPAD_MAX; num++) {
+        XINPUT_STATE state;
+        WORD buttons;
+        float lx, ly, rx, ry;
+
+        if (XInputGetState(num, &state) != ERROR_SUCCESS) {
+            gamepads->gamepads[num].available = nk_false;
+            continue;
+        }
+        gamepads->gamepads[num].available = nk_true;
+
+        buttons = state.Gamepad.wButtons;
+        nk_gamepad_button(gamepads, num, NK_GAMEPAD_BUTTON_UP,    (buttons & XINPUT_GAMEPAD_DPAD_UP)         != 0);
+        nk_gamepad_button(gamepads, num, NK_GAMEPAD_BUTTON_DOWN,  (buttons & XINPUT_GAMEPAD_DPAD_DOWN)       != 0);
+        nk_gamepad_button(gamepads, num, NK_GAMEPAD_BUTTON_LEFT,  (buttons & XINPUT_GAMEPAD_DPAD_LEFT)       != 0);
+        nk_gamepad_button(gamepads, num, NK_GAMEPAD_BUTTON_RIGHT, (buttons & XINPUT_GAMEPAD_DPAD_RIGHT)      != 0);
+        nk_gamepad_button(gamepads, num, NK_GAMEPAD_BUTTON_A,     (buttons & XINPUT_GAMEPAD_A)               != 0);
+        nk_gamepad_button(gamepads, num, NK_GAMEPAD_BUTTON_B,     (buttons & XINPUT_GAMEPAD_B)               != 0);
+        nk_gamepad_button(gamepads, num, NK_GAMEPAD_BUTTON_X,     (buttons & XINPUT_GAMEPAD_X)               != 0);
+        nk_gamepad_button(gamepads, num, NK_GAMEPAD_BUTTON_Y,     (buttons & XINPUT_GAMEPAD_Y)               != 0);
+        nk_gamepad_button(gamepads, num, NK_GAMEPAD_BUTTON_LB,    (buttons & XINPUT_GAMEPAD_LEFT_SHOULDER)   != 0);
+        nk_gamepad_button(gamepads, num, NK_GAMEPAD_BUTTON_RB,    (buttons & XINPUT_GAMEPAD_RIGHT_SHOULDER)  != 0);
+        nk_gamepad_button(gamepads, num, NK_GAMEPAD_BUTTON_BACK,  (buttons & XINPUT_GAMEPAD_BACK)            != 0);
+        nk_gamepad_button(gamepads, num, NK_GAMEPAD_BUTTON_START, (buttons & XINPUT_GAMEPAD_START)           != 0);
+
+        /* Normalize thumb sticks from -32768..32767 to -1..1 */
+        lx = state.Gamepad.sThumbLX / 32767.0f;
+        ly = state.Gamepad.sThumbLY / 32767.0f;
+        rx = state.Gamepad.sThumbRX / 32767.0f;
+        ry = state.Gamepad.sThumbRY / 32767.0f;
+        if (lx >  1.0f) lx =  1.0f; if (lx < -1.0f) lx = -1.0f;
+        if (ly >  1.0f) ly =  1.0f; if (ly < -1.0f) ly = -1.0f;
+        if (rx >  1.0f) rx =  1.0f; if (rx < -1.0f) rx = -1.0f;
+        if (ry >  1.0f) ry =  1.0f; if (ry < -1.0f) ry = -1.0f;
+        nk_gamepad_axis(gamepads, num, NK_GAMEPAD_AXIS_LEFT_X,  lx);
+        nk_gamepad_axis(gamepads, num, NK_GAMEPAD_AXIS_LEFT_Y,  -ly);
+        nk_gamepad_axis(gamepads, num, NK_GAMEPAD_AXIS_RIGHT_X, rx);
+        nk_gamepad_axis(gamepads, num, NK_GAMEPAD_AXIS_RIGHT_Y, -ry);
+
+        /* Normalize triggers from 0..255 to 0..1 */
+        nk_gamepad_axis(gamepads, num, NK_GAMEPAD_AXIS_LEFT_TRIGGER,  state.Gamepad.bLeftTrigger  / 255.0f);
+        nk_gamepad_axis(gamepads, num, NK_GAMEPAD_AXIS_RIGHT_TRIGGER, state.Gamepad.bRightTrigger / 255.0f);
+    }
+}
+
+NK_API const char* nk_gamepad_xinput_name(struct nk_gamepads* gamepads, int num, void* user_data) {
+    NK_UNUSED(user_data);
+    if (num < 0 || num >= NK_GAMEPAD_MAX || !gamepads->gamepads[num].available) {
+        return NULL;
+    }
+    return gamepads->gamepads[num].name;
+}
+
+NK_API struct nk_gamepad_input_source nk_gamepad_xinput_input_source(void* user_data) {
+    struct nk_gamepad_input_source source;
+    source.user_data = user_data;
+    source.init = &nk_gamepad_xinput_init;
+    source.update = &nk_gamepad_xinput_update;
+    source.free = NULL;
+    source.name = &nk_gamepad_xinput_name;
+    source.button_name = NULL;
+    source.input_source_name = "XInput";
+    source.id = NK_GAMEPAD_INPUT_SOURCE_XINPUT;
+    return source;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+#endif


### PR DESCRIPTION
Implements XInput support via `nuklear_gamepad_xinput.h`, mapping all buttons and axes including triggers and thumb sticks. Fixes #14