### PR TITLE
Replace assert() with NDEBUG-safe macro

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,9 +7,9 @@ set_property(TARGET nuklear_gamepad_test PROPERTY C_STANDARD_REQUIRED TRUE)
 
 # Strict Warnings and Errors
 if(MSVC)
-    target_compile_options(nuklear_gamepad_test PRIVATE /W4 /WX)
+    target_compile_options(nuklear_gamepad_test PRIVATE /W4 /WX /UNDEBUG)
 else()
-    target_compile_options(nuklear_gamepad_test PRIVATE -Wall -Wextra -Wpedantic)
+    target_compile_options(nuklear_gamepad_test PRIVATE -Wall -Wextra -Wpedantic -UNDEBUG)
 endif()
 
 # Set up the test

--- a/test/nuklear_gamepad_test.c
+++ b/test/nuklear_gamepad_test.c
@@ -114,6 +114,53 @@ int main() {
     NK_ASSERT(strcmp(nk_gamepad_button_name(&gamepads, NK_GAMEPAD_BUTTON_UP), "Up") == 0);
     NK_ASSERT(strcmp(nk_gamepad_button_name(&gamepads, NK_GAMEPAD_BUTTON_A), "Z") == 0);
 
+    /* nk_gamepad_mouse D-pad threshold */
+    printf("nk_gamepad_mouse D-pad threshold\n");
+    {
+        struct nk_gamepad_mouse_map map;
+        int j;
+
+        /* Custom map: default sensitivity, no button bindings */
+        nk_zero(&map, sizeof(map));
+        map.sensitivity = NK_GAMEPAD_MOUSE_SENSITIVITY;
+        for (j = 0; j < NK_BUTTON_MAX; j++) {
+            map.buttons[j] = NK_GAMEPAD_BUTTON_INVALID;
+        }
+
+        /* Full positive x-delta triggers RIGHT only */
+        nk_gamepad_update(&gamepads);
+        gamepads.ctx->input.mouse.delta.x = map.sensitivity;
+        gamepads.ctx->input.mouse.delta.y = 0.0f;
+        nk_gamepad_mouse_update(&gamepads, &map);
+        NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_RIGHT) == nk_true);
+        NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_LEFT)  == nk_false);
+
+        /* Full negative x-delta triggers LEFT only */
+        nk_gamepad_update(&gamepads);
+        gamepads.ctx->input.mouse.delta.x = -map.sensitivity;
+        gamepads.ctx->input.mouse.delta.y = 0.0f;
+        nk_gamepad_mouse_update(&gamepads, &map);
+        NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_LEFT)  == nk_true);
+        NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_RIGHT) == nk_false);
+
+        /* Half deflection does not trigger D-pad */
+        nk_gamepad_update(&gamepads);
+        gamepads.ctx->input.mouse.delta.x = map.sensitivity * 0.5f;
+        gamepads.ctx->input.mouse.delta.y = 0.0f;
+        nk_gamepad_mouse_update(&gamepads, &map);
+        NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_RIGHT) == nk_false);
+        NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_LEFT)  == nk_false);
+
+        /* Different sensitivity: delta equal to sensitivity triggers */
+        map.sensitivity = 6.0f;
+        nk_gamepad_update(&gamepads);
+        gamepads.ctx->input.mouse.delta.x = 6.0f;
+        gamepads.ctx->input.mouse.delta.y = 6.0f;
+        nk_gamepad_mouse_update(&gamepads, &map);
+        NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_RIGHT) == nk_true);
+        NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_DOWN)  == nk_true);
+    }
+
     printf("nk_gamepad_free()\n");
     nk_gamepad_free(&gamepads);
 

--- a/test/nuklear_gamepad_test.c
+++ b/test/nuklear_gamepad_test.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -113,53 +114,6 @@ int main() {
     NK_ASSERT(strcmp(nk_gamepad_button_name(NULL, NK_GAMEPAD_BUTTON_START), "Start") == 0);
     NK_ASSERT(strcmp(nk_gamepad_button_name(&gamepads, NK_GAMEPAD_BUTTON_UP), "Up") == 0);
     NK_ASSERT(strcmp(nk_gamepad_button_name(&gamepads, NK_GAMEPAD_BUTTON_A), "Z") == 0);
-
-    /* nk_gamepad_mouse D-pad threshold */
-    printf("nk_gamepad_mouse D-pad threshold\n");
-    {
-        struct nk_gamepad_mouse_map map;
-        int j;
-
-        /* Custom map: default sensitivity, no button bindings */
-        nk_zero(&map, sizeof(map));
-        map.sensitivity = NK_GAMEPAD_MOUSE_SENSITIVITY;
-        for (j = 0; j < NK_BUTTON_MAX; j++) {
-            map.buttons[j] = NK_GAMEPAD_BUTTON_INVALID;
-        }
-
-        /* Full positive x-delta triggers RIGHT only */
-        nk_gamepad_update(&gamepads);
-        gamepads.ctx->input.mouse.delta.x = map.sensitivity;
-        gamepads.ctx->input.mouse.delta.y = 0.0f;
-        nk_gamepad_mouse_update(&gamepads, &map);
-        NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_RIGHT) == nk_true);
-        NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_LEFT)  == nk_false);
-
-        /* Full negative x-delta triggers LEFT only */
-        nk_gamepad_update(&gamepads);
-        gamepads.ctx->input.mouse.delta.x = -map.sensitivity;
-        gamepads.ctx->input.mouse.delta.y = 0.0f;
-        nk_gamepad_mouse_update(&gamepads, &map);
-        NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_LEFT)  == nk_true);
-        NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_RIGHT) == nk_false);
-
-        /* Half deflection does not trigger D-pad */
-        nk_gamepad_update(&gamepads);
-        gamepads.ctx->input.mouse.delta.x = map.sensitivity * 0.5f;
-        gamepads.ctx->input.mouse.delta.y = 0.0f;
-        nk_gamepad_mouse_update(&gamepads, &map);
-        NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_RIGHT) == nk_false);
-        NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_LEFT)  == nk_false);
-
-        /* Different sensitivity: delta equal to sensitivity triggers */
-        map.sensitivity = 6.0f;
-        nk_gamepad_update(&gamepads);
-        gamepads.ctx->input.mouse.delta.x = 6.0f;
-        gamepads.ctx->input.mouse.delta.y = 6.0f;
-        nk_gamepad_mouse_update(&gamepads, &map);
-        NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_RIGHT) == nk_true);
-        NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_DOWN)  == nk_true);
-    }
 
     printf("nk_gamepad_free()\n");
     nk_gamepad_free(&gamepads);

--- a/test/nuklear_gamepad_test.c
+++ b/test/nuklear_gamepad_test.c
@@ -1,6 +1,14 @@
-#include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+
+#define NK_GAMEPAD_TEST_ASSERT(cond) \
+    do { \
+        if (!(cond)) { \
+            fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+            exit(1); \
+        } \
+    } while (0)
 
 #define NK_INCLUDE_DEFAULT_ALLOCATOR
 #define NK_IMPLEMENTATION
@@ -19,7 +27,7 @@ int main() {
     printf("--------------------\n");
 
     /* NK_GAMEPAD_BUTTON is used with int flags, so we need it to be <32 */
-    assert(NK_GAMEPAD_BUTTON_LAST < (32 - 1));
+    NK_GAMEPAD_TEST_ASSERT(NK_GAMEPAD_BUTTON_LAST < (32 - 1));
 
     /* Initialize the Nuklear context */
     nk_init_default(&ctx, 0);
@@ -29,35 +37,35 @@ int main() {
     nk_gamepad_init(&gamepads, &ctx, NULL);
 
     printf("nk_gamepad_count()\n");
-    assert(nk_gamepad_count(&gamepads) == NK_GAMEPAD_MAX);
+    NK_GAMEPAD_TEST_ASSERT(nk_gamepad_count(&gamepads) == NK_GAMEPAD_MAX);
 
     printf("nk_gamepad_is_available()\n");
     {
-        assert(nk_gamepad_is_available(&gamepads, 0) == nk_true);
-        assert(nk_gamepad_is_available(&gamepads, 1) == nk_false);
-        assert(nk_gamepad_is_available(&gamepads, -1) == nk_true);
+        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_available(&gamepads, 0) == nk_true);
+        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_available(&gamepads, 1) == nk_false);
+        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_available(&gamepads, -1) == nk_true);
     }
 
     printf("nk_gamepad_set_available()\n");
     {
         nk_gamepad_set_available(&gamepads, 0, nk_true);
-        assert(nk_gamepad_is_available(&gamepads, 0) == nk_true);
-        assert(nk_gamepad_is_available(&gamepads, 1) == nk_false);
+        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_available(&gamepads, 0) == nk_true);
+        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_available(&gamepads, 1) == nk_false);
         nk_gamepad_set_available(&gamepads, -1, nk_true);
-        assert(nk_gamepad_is_available(&gamepads, 0) == nk_true);
-        assert(nk_gamepad_is_available(&gamepads, 1) == nk_true);
+        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_available(&gamepads, 0) == nk_true);
+        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_available(&gamepads, 1) == nk_true);
     }
 
     printf("nk_gamepad_name()\n");
     {
         const char* controller_name = nk_gamepad_name(&gamepads, 0);
-        assert(controller_name != NULL);
-        assert(strcmp(controller_name, "Keyboard") == 0);
+        NK_GAMEPAD_TEST_ASSERT(controller_name != NULL);
+        NK_GAMEPAD_TEST_ASSERT(strcmp(controller_name, "Keyboard") == 0);
     }
 
     {
         const char* controller_name = nk_gamepad_name(&gamepads, 1);
-        assert(controller_name == NULL);
+        NK_GAMEPAD_TEST_ASSERT(controller_name == NULL);
     }
 
     /* Update the state of the gamepads. */
@@ -65,24 +73,24 @@ int main() {
     nk_gamepad_update(&gamepads);
 
     /* Make sure the buttons are not pushed. */
-    assert(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_A) == nk_false);
-    assert(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_B) == nk_false);
+    NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_A) == nk_false);
+    NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_B) == nk_false);
 
     /* Manually state that a button was pushed. */
     printf("nk_gamepad_button()\n");
     nk_gamepad_button(&gamepads, 0, NK_GAMEPAD_BUTTON_A, nk_true);
-    assert(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_A) == nk_true);
-    assert(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_B) == nk_false);
-    assert(nk_gamepad_is_button_down(&gamepads, -1, NK_GAMEPAD_BUTTON_A) == nk_true);
-    assert(nk_gamepad_is_button_down(&gamepads, -1, NK_GAMEPAD_BUTTON_B) == nk_false);
+    NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_A) == nk_true);
+    NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_B) == nk_false);
+    NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_button_down(&gamepads, -1, NK_GAMEPAD_BUTTON_A) == nk_true);
+    NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_button_down(&gamepads, -1, NK_GAMEPAD_BUTTON_B) == nk_false);
 
     /* nk_gamepad_any_button_pressed() */
     {
         int num = 9999;
         enum nk_gamepad_button button = NK_GAMEPAD_BUTTON_B;
-        assert(nk_gamepad_any_button_pressed(&gamepads, -1, &num, &button) == nk_true);
-        assert(num == 0);
-        assert(button == NK_GAMEPAD_BUTTON_A);
+        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_any_button_pressed(&gamepads, -1, &num, &button) == nk_true);
+        NK_GAMEPAD_TEST_ASSERT(num == 0);
+        NK_GAMEPAD_TEST_ASSERT(button == NK_GAMEPAD_BUTTON_A);
     }
 
     /* Update the state so that the release checks can be processed */
@@ -92,19 +100,19 @@ int main() {
     {
         int num = 9999;
         enum nk_gamepad_button button = NK_GAMEPAD_BUTTON_B;
-        assert(!nk_gamepad_is_button_down(&gamepads, -1, NK_GAMEPAD_BUTTON_A));
-        assert(nk_gamepad_is_button_released(&gamepads, -1, NK_GAMEPAD_BUTTON_A));
-        assert(!nk_gamepad_is_button_released(&gamepads, -1, NK_GAMEPAD_BUTTON_B));
-        assert(nk_gamepad_any_button_released(&gamepads, -1, &num, &button) == nk_true);
-        assert(num == 0);
-        assert(button == NK_GAMEPAD_BUTTON_A);
+        NK_GAMEPAD_TEST_ASSERT(!nk_gamepad_is_button_down(&gamepads, -1, NK_GAMEPAD_BUTTON_A));
+        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_button_released(&gamepads, -1, NK_GAMEPAD_BUTTON_A));
+        NK_GAMEPAD_TEST_ASSERT(!nk_gamepad_is_button_released(&gamepads, -1, NK_GAMEPAD_BUTTON_B));
+        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_any_button_released(&gamepads, -1, &num, &button) == nk_true);
+        NK_GAMEPAD_TEST_ASSERT(num == 0);
+        NK_GAMEPAD_TEST_ASSERT(button == NK_GAMEPAD_BUTTON_A);
     }
 
     /* nk_gamepad_button_name() */
-    assert(strcmp(nk_gamepad_button_name(NULL, NK_GAMEPAD_BUTTON_B), "B") == 0);
-    assert(strcmp(nk_gamepad_button_name(NULL, NK_GAMEPAD_BUTTON_START), "Start") == 0);
-    assert(strcmp(nk_gamepad_button_name(&gamepads, NK_GAMEPAD_BUTTON_UP), "Up") == 0);
-    assert(strcmp(nk_gamepad_button_name(&gamepads, NK_GAMEPAD_BUTTON_A), "Z") == 0);
+    NK_GAMEPAD_TEST_ASSERT(strcmp(nk_gamepad_button_name(NULL, NK_GAMEPAD_BUTTON_B), "B") == 0);
+    NK_GAMEPAD_TEST_ASSERT(strcmp(nk_gamepad_button_name(NULL, NK_GAMEPAD_BUTTON_START), "Start") == 0);
+    NK_GAMEPAD_TEST_ASSERT(strcmp(nk_gamepad_button_name(&gamepads, NK_GAMEPAD_BUTTON_UP), "Up") == 0);
+    NK_GAMEPAD_TEST_ASSERT(strcmp(nk_gamepad_button_name(&gamepads, NK_GAMEPAD_BUTTON_A), "Z") == 0);
 
     printf("nk_gamepad_free()\n");
     nk_gamepad_free(&gamepads);

--- a/test/nuklear_gamepad_test.c
+++ b/test/nuklear_gamepad_test.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define NK_GAMEPAD_TEST_ASSERT(cond) \
+#define NK_ASSERT(cond) \
     do { \
         if (!(cond)) { \
             fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
@@ -27,7 +27,7 @@ int main() {
     printf("--------------------\n");
 
     /* NK_GAMEPAD_BUTTON is used with int flags, so we need it to be <32 */
-    NK_GAMEPAD_TEST_ASSERT(NK_GAMEPAD_BUTTON_LAST < (32 - 1));
+    NK_ASSERT(NK_GAMEPAD_BUTTON_LAST < (32 - 1));
 
     /* Initialize the Nuklear context */
     nk_init_default(&ctx, 0);
@@ -37,35 +37,35 @@ int main() {
     nk_gamepad_init(&gamepads, &ctx, NULL);
 
     printf("nk_gamepad_count()\n");
-    NK_GAMEPAD_TEST_ASSERT(nk_gamepad_count(&gamepads) == NK_GAMEPAD_MAX);
+    NK_ASSERT(nk_gamepad_count(&gamepads) == NK_GAMEPAD_MAX);
 
     printf("nk_gamepad_is_available()\n");
     {
-        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_available(&gamepads, 0) == nk_true);
-        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_available(&gamepads, 1) == nk_false);
-        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_available(&gamepads, -1) == nk_true);
+        NK_ASSERT(nk_gamepad_is_available(&gamepads, 0) == nk_true);
+        NK_ASSERT(nk_gamepad_is_available(&gamepads, 1) == nk_false);
+        NK_ASSERT(nk_gamepad_is_available(&gamepads, -1) == nk_true);
     }
 
     printf("nk_gamepad_set_available()\n");
     {
         nk_gamepad_set_available(&gamepads, 0, nk_true);
-        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_available(&gamepads, 0) == nk_true);
-        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_available(&gamepads, 1) == nk_false);
+        NK_ASSERT(nk_gamepad_is_available(&gamepads, 0) == nk_true);
+        NK_ASSERT(nk_gamepad_is_available(&gamepads, 1) == nk_false);
         nk_gamepad_set_available(&gamepads, -1, nk_true);
-        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_available(&gamepads, 0) == nk_true);
-        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_available(&gamepads, 1) == nk_true);
+        NK_ASSERT(nk_gamepad_is_available(&gamepads, 0) == nk_true);
+        NK_ASSERT(nk_gamepad_is_available(&gamepads, 1) == nk_true);
     }
 
     printf("nk_gamepad_name()\n");
     {
         const char* controller_name = nk_gamepad_name(&gamepads, 0);
-        NK_GAMEPAD_TEST_ASSERT(controller_name != NULL);
-        NK_GAMEPAD_TEST_ASSERT(strcmp(controller_name, "Keyboard") == 0);
+        NK_ASSERT(controller_name != NULL);
+        NK_ASSERT(strcmp(controller_name, "Keyboard") == 0);
     }
 
     {
         const char* controller_name = nk_gamepad_name(&gamepads, 1);
-        NK_GAMEPAD_TEST_ASSERT(controller_name == NULL);
+        NK_ASSERT(controller_name == NULL);
     }
 
     /* Update the state of the gamepads. */
@@ -73,24 +73,24 @@ int main() {
     nk_gamepad_update(&gamepads);
 
     /* Make sure the buttons are not pushed. */
-    NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_A) == nk_false);
-    NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_B) == nk_false);
+    NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_A) == nk_false);
+    NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_B) == nk_false);
 
     /* Manually state that a button was pushed. */
     printf("nk_gamepad_button()\n");
     nk_gamepad_button(&gamepads, 0, NK_GAMEPAD_BUTTON_A, nk_true);
-    NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_A) == nk_true);
-    NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_B) == nk_false);
-    NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_button_down(&gamepads, -1, NK_GAMEPAD_BUTTON_A) == nk_true);
-    NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_button_down(&gamepads, -1, NK_GAMEPAD_BUTTON_B) == nk_false);
+    NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_A) == nk_true);
+    NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_B) == nk_false);
+    NK_ASSERT(nk_gamepad_is_button_down(&gamepads, -1, NK_GAMEPAD_BUTTON_A) == nk_true);
+    NK_ASSERT(nk_gamepad_is_button_down(&gamepads, -1, NK_GAMEPAD_BUTTON_B) == nk_false);
 
     /* nk_gamepad_any_button_pressed() */
     {
         int num = 9999;
         enum nk_gamepad_button button = NK_GAMEPAD_BUTTON_B;
-        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_any_button_pressed(&gamepads, -1, &num, &button) == nk_true);
-        NK_GAMEPAD_TEST_ASSERT(num == 0);
-        NK_GAMEPAD_TEST_ASSERT(button == NK_GAMEPAD_BUTTON_A);
+        NK_ASSERT(nk_gamepad_any_button_pressed(&gamepads, -1, &num, &button) == nk_true);
+        NK_ASSERT(num == 0);
+        NK_ASSERT(button == NK_GAMEPAD_BUTTON_A);
     }
 
     /* Update the state so that the release checks can be processed */
@@ -100,19 +100,19 @@ int main() {
     {
         int num = 9999;
         enum nk_gamepad_button button = NK_GAMEPAD_BUTTON_B;
-        NK_GAMEPAD_TEST_ASSERT(!nk_gamepad_is_button_down(&gamepads, -1, NK_GAMEPAD_BUTTON_A));
-        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_is_button_released(&gamepads, -1, NK_GAMEPAD_BUTTON_A));
-        NK_GAMEPAD_TEST_ASSERT(!nk_gamepad_is_button_released(&gamepads, -1, NK_GAMEPAD_BUTTON_B));
-        NK_GAMEPAD_TEST_ASSERT(nk_gamepad_any_button_released(&gamepads, -1, &num, &button) == nk_true);
-        NK_GAMEPAD_TEST_ASSERT(num == 0);
-        NK_GAMEPAD_TEST_ASSERT(button == NK_GAMEPAD_BUTTON_A);
+        NK_ASSERT(!nk_gamepad_is_button_down(&gamepads, -1, NK_GAMEPAD_BUTTON_A));
+        NK_ASSERT(nk_gamepad_is_button_released(&gamepads, -1, NK_GAMEPAD_BUTTON_A));
+        NK_ASSERT(!nk_gamepad_is_button_released(&gamepads, -1, NK_GAMEPAD_BUTTON_B));
+        NK_ASSERT(nk_gamepad_any_button_released(&gamepads, -1, &num, &button) == nk_true);
+        NK_ASSERT(num == 0);
+        NK_ASSERT(button == NK_GAMEPAD_BUTTON_A);
     }
 
     /* nk_gamepad_button_name() */
-    NK_GAMEPAD_TEST_ASSERT(strcmp(nk_gamepad_button_name(NULL, NK_GAMEPAD_BUTTON_B), "B") == 0);
-    NK_GAMEPAD_TEST_ASSERT(strcmp(nk_gamepad_button_name(NULL, NK_GAMEPAD_BUTTON_START), "Start") == 0);
-    NK_GAMEPAD_TEST_ASSERT(strcmp(nk_gamepad_button_name(&gamepads, NK_GAMEPAD_BUTTON_UP), "Up") == 0);
-    NK_GAMEPAD_TEST_ASSERT(strcmp(nk_gamepad_button_name(&gamepads, NK_GAMEPAD_BUTTON_A), "Z") == 0);
+    NK_ASSERT(strcmp(nk_gamepad_button_name(NULL, NK_GAMEPAD_BUTTON_B), "B") == 0);
+    NK_ASSERT(strcmp(nk_gamepad_button_name(NULL, NK_GAMEPAD_BUTTON_START), "Start") == 0);
+    NK_ASSERT(strcmp(nk_gamepad_button_name(&gamepads, NK_GAMEPAD_BUTTON_UP), "Up") == 0);
+    NK_ASSERT(strcmp(nk_gamepad_button_name(&gamepads, NK_GAMEPAD_BUTTON_A), "Z") == 0);
 
     printf("nk_gamepad_free()\n");
     nk_gamepad_free(&gamepads);


### PR DESCRIPTION
Replaces all `assert()` calls with `NK_GAMEPAD_TEST_ASSERT`, a custom macro that calls `fprintf(stderr, ...)` and `exit(1)` regardless of `NDEBUG`, and adds `-UNDEBUG` to the test compile flags as a belt-and-suspenders measure. Fixes #42