### PR TITLE
Fix C89 compat in SDL/SDL3/raylib backends

### DIFF
--- a/nuklear_gamepad_raylib.h
+++ b/nuklear_gamepad_raylib.h
@@ -43,25 +43,27 @@ int nk_gamepad_raylib_map_button(int button) {
 }
 
 void nk_gamepad_raylib_update(struct nk_gamepads* gamepads, void* user_data) {
+    int num;
+    int i;
     NK_UNUSED(user_data);
     if (!gamepads) {
         return;
     }
 
-    for (int num = 0; num < NK_GAMEPAD_MAX; num++) {
+    for (num = 0; num < NK_GAMEPAD_MAX; num++) {
         if (!IsGamepadAvailable(num)) {
             gamepads->gamepads[num].available = nk_false;
             continue;
         }
 
         gamepads->gamepads[num].available = nk_true;
-        for (int i = NK_GAMEPAD_BUTTON_FIRST; i < NK_GAMEPAD_BUTTON_LAST; i++) {
+        for (i = NK_GAMEPAD_BUTTON_FIRST; i < NK_GAMEPAD_BUTTON_LAST; i++) {
             if (IsGamepadButtonDown(num, nk_gamepad_raylib_map_button(i))) {
                 nk_gamepad_button(gamepads, num, (enum nk_gamepad_button)i, nk_true);
             }
         }
 
-        // Axes: raylib returns -1..1 for sticks and 0..1 for triggers
+        /* Axes: raylib returns -1..1 for sticks and 0..1 for triggers */
         nk_gamepad_axis(gamepads, num, NK_GAMEPAD_AXIS_LEFT_X,       GetGamepadAxisMovement(num, GAMEPAD_AXIS_LEFT_X));
         nk_gamepad_axis(gamepads, num, NK_GAMEPAD_AXIS_LEFT_Y,       GetGamepadAxisMovement(num, GAMEPAD_AXIS_LEFT_Y));
         nk_gamepad_axis(gamepads, num, NK_GAMEPAD_AXIS_RIGHT_X,      GetGamepadAxisMovement(num, GAMEPAD_AXIS_RIGHT_X));
@@ -72,8 +74,9 @@ void nk_gamepad_raylib_update(struct nk_gamepads* gamepads, void* user_data) {
 }
 
 const char* nk_gamepad_raylib_name(struct nk_gamepads* gamepads, int num, void* user_data) {
+    const char* name;
     NK_UNUSED(user_data);
-    const char* name = GetGamepadName(num);
+    name = GetGamepadName(num);
     if (name == NULL || TextLength(name) == 0) {
         return gamepads->gamepads[num].name;
     }
@@ -82,16 +85,15 @@ const char* nk_gamepad_raylib_name(struct nk_gamepads* gamepads, int num, void* 
 }
 
 NK_API struct nk_gamepad_input_source nk_gamepad_raylib_input_source(void* user_data) {
-    struct nk_gamepad_input_source source = {
-        .user_data = user_data,
-        .init = NULL,
-        .update = &nk_gamepad_raylib_update,
-        .free = NULL,
-        .name = &nk_gamepad_raylib_name,
-        .button_name = NULL,
-        .input_source_name = "raylib",
-        .id = NK_GAMEPAD_INPUT_SOURCE_RAYLIB,
-    };
+    struct nk_gamepad_input_source source;
+    source.user_data = user_data;
+    source.init = NULL;
+    source.update = &nk_gamepad_raylib_update;
+    source.free = NULL;
+    source.name = &nk_gamepad_raylib_name;
+    source.button_name = NULL;
+    source.input_source_name = "raylib";
+    source.id = NK_GAMEPAD_INPUT_SOURCE_RAYLIB;
     return source;
 }
 

--- a/nuklear_gamepad_sdl.h
+++ b/nuklear_gamepad_sdl.h
@@ -40,11 +40,13 @@ NK_API void nk_gamepad_sdl_handle_event(struct nk_gamepads* gamepads, SDL_Event 
             break;
         }
         case SDL_CONTROLLERDEVICEREMOVED: {
-            SDL_GameController* controller = SDL_GameControllerFromInstanceID(event->cdevice.which);
+            int i;
+            SDL_GameController* controller;
+            controller = SDL_GameControllerFromInstanceID(event->cdevice.which);
             if (controller == NULL) {
                 break;
             }
-            for (int i = 0; i < NK_GAMEPAD_MAX; i++) {
+            for (i = 0; i < NK_GAMEPAD_MAX; i++) {
                 if (gamepads->gamepads[i].data == controller) {
                     SDL_GameControllerClose(controller);
                     gamepads->gamepads[i].data = NULL;
@@ -58,12 +60,13 @@ NK_API void nk_gamepad_sdl_handle_event(struct nk_gamepads* gamepads, SDL_Event 
 }
 
 NK_API nk_bool nk_gamepad_sdl_init(struct nk_gamepads* gamepads, void* user_data) {
+    int i;
     NK_UNUSED(user_data);
     if (gamepads == NULL) {
         return nk_false;
     }
 
-    for (int i = 0; i < NK_GAMEPAD_MAX; i++) {
+    for (i = 0; i < NK_GAMEPAD_MAX; i++) {
         if (SDL_IsGameController(i)) {
             SDL_GameController* controller = SDL_GameControllerOpen(i);
             if (controller != NULL) {
@@ -81,12 +84,13 @@ NK_API nk_bool nk_gamepad_sdl_init(struct nk_gamepads* gamepads, void* user_data
 }
 
 NK_API void nk_gamepad_sdl_free(struct nk_gamepads* gamepads, void* user_data) {
+    int i;
     NK_UNUSED(user_data);
     if (!gamepads) {
         return;
     }
 
-    for (int i = 0; i < NK_GAMEPAD_MAX; i++) {
+    for (i = 0; i < NK_GAMEPAD_MAX; i++) {
         if (gamepads->gamepads[i].data != NULL) {
             SDL_GameControllerClose((SDL_GameController*)gamepads->gamepads[i].data);
             gamepads->gamepads[i].data = NULL;
@@ -115,15 +119,18 @@ SDL_GameControllerButton nk_gamepad_sdl_map_button(int button) {
 }
 
 NK_API void nk_gamepad_sdl_update(struct nk_gamepads* gamepads, void* user_data) {
+    int num;
+    int i;
+    SDL_GameController* controller;
     NK_UNUSED(user_data);
-    for (int num = 0; num < NK_GAMEPAD_MAX; num++) {
+    for (num = 0; num < NK_GAMEPAD_MAX; num++) {
         if (gamepads->gamepads[num].data == NULL) {
             continue;
         }
 
-        SDL_GameController* controller = (SDL_GameController*)gamepads->gamepads[num].data;
+        controller = (SDL_GameController*)gamepads->gamepads[num].data;
 
-        // Check to make sure it's still attached.
+        /* Check to make sure it's still attached. */
         if (SDL_GameControllerGetAttached(controller) == SDL_FALSE) {
             gamepads->gamepads[num].available = nk_false;
             SDL_GameControllerClose(controller);
@@ -131,13 +138,13 @@ NK_API void nk_gamepad_sdl_update(struct nk_gamepads* gamepads, void* user_data)
             continue;
         }
 
-        for (int i = NK_GAMEPAD_BUTTON_FIRST; i < NK_GAMEPAD_BUTTON_LAST; i++) {
+        for (i = NK_GAMEPAD_BUTTON_FIRST; i < NK_GAMEPAD_BUTTON_LAST; i++) {
             if (SDL_GameControllerGetButton(controller, nk_gamepad_sdl_map_button(i))) {
                 nk_gamepad_button(gamepads, num, (enum nk_gamepad_button)i, nk_true);
             }
         }
 
-        // Axes: SDL returns Sint16 in range -32768..32767 (sticks) or 0..32767 (triggers)
+        /* Axes: SDL returns Sint16 in range -32768..32767 (sticks) or 0..32767 (triggers) */
         nk_gamepad_axis(gamepads, num, NK_GAMEPAD_AXIS_LEFT_X, SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTX) / 32767.0f);
         nk_gamepad_axis(gamepads, num, NK_GAMEPAD_AXIS_LEFT_Y, SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_LEFTY) / 32767.0f);
         nk_gamepad_axis(gamepads, num, NK_GAMEPAD_AXIS_RIGHT_X, SDL_GameControllerGetAxis(controller, SDL_CONTROLLER_AXIS_RIGHTX) / 32767.0f);
@@ -148,12 +155,13 @@ NK_API void nk_gamepad_sdl_update(struct nk_gamepads* gamepads, void* user_data)
 }
 
 NK_API const char* nk_gamepad_sdl_name(struct nk_gamepads* gamepads, int num, void* user_data) {
+    const char* name;
     NK_UNUSED(user_data);
     if (gamepads->gamepads[num].data == NULL) {
         return NULL;
     }
 
-    const char* name = SDL_GameControllerName((SDL_GameController*)gamepads->gamepads[num].data);
+    name = SDL_GameControllerName((SDL_GameController*)gamepads->gamepads[num].data);
     if (name == NULL || name[0] == '\0') {
         return gamepads->gamepads[num].name;
     }
@@ -162,16 +170,15 @@ NK_API const char* nk_gamepad_sdl_name(struct nk_gamepads* gamepads, int num, vo
 }
 
 NK_API struct nk_gamepad_input_source nk_gamepad_sdl_input_source(void* user_data) {
-    struct nk_gamepad_input_source source = {
-        .user_data = user_data,
-        .init = &nk_gamepad_sdl_init,
-        .update = &nk_gamepad_sdl_update,
-        .free = &nk_gamepad_sdl_free,
-        .name = &nk_gamepad_sdl_name,
-        .button_name = NULL,
-        .input_source_name = "SDL",
-        .id = NK_GAMEPAD_INPUT_SOURCE_SDL,
-    };
+    struct nk_gamepad_input_source source;
+    source.user_data = user_data;
+    source.init = &nk_gamepad_sdl_init;
+    source.update = &nk_gamepad_sdl_update;
+    source.free = &nk_gamepad_sdl_free;
+    source.name = &nk_gamepad_sdl_name;
+    source.button_name = NULL;
+    source.input_source_name = "SDL";
+    source.id = NK_GAMEPAD_INPUT_SOURCE_SDL;
     return source;
 }
 

--- a/nuklear_gamepad_sdl3.h
+++ b/nuklear_gamepad_sdl3.h
@@ -102,7 +102,8 @@ NK_API void nk_gamepad_sdl3_handle_event(struct nk_gamepads* gamepads, SDL_Event
             SDL_JoystickID which = event->gdevice.which;
             if (SDL_IsGamepad(which)) {
                 int first_free = -1;
-                for (int i = 0; i < NK_GAMEPAD_MAX; i++) {
+                int i;
+                for (i = 0; i < NK_GAMEPAD_MAX; i++) {
                     if (gamepads->gamepads[i].data != NULL &&
                         SDL_GetGamepadID((SDL_Gamepad*)gamepads->gamepads[i].data) == which) {
                         first_free = -1;
@@ -123,7 +124,8 @@ NK_API void nk_gamepad_sdl3_handle_event(struct nk_gamepads* gamepads, SDL_Event
             break;
         }
         case SDL_EVENT_GAMEPAD_REMOVED: {
-            for (int i = 0; i < NK_GAMEPAD_MAX; i++) {
+            int i;
+            for (i = 0; i < NK_GAMEPAD_MAX; i++) {
                 if (gamepads->gamepads[i].data != NULL &&
                     SDL_GetGamepadID((SDL_Gamepad*)gamepads->gamepads[i].data) == event->gdevice.which) {
                     SDL_CloseGamepad((SDL_Gamepad*)gamepads->gamepads[i].data);
@@ -138,13 +140,15 @@ NK_API void nk_gamepad_sdl3_handle_event(struct nk_gamepads* gamepads, SDL_Event
 }
 
 NK_API nk_bool nk_gamepad_sdl3_init(struct nk_gamepads* gamepads, void* user_data) {
+    int count;
+    SDL_JoystickID* joysticks;
     NK_UNUSED(user_data);
     if (gamepads == NULL) {
         return nk_false;
     }
 
-    int count = 0;
-    SDL_JoystickID* joysticks = SDL_GetGamepads(&count);
+    count = 0;
+    joysticks = SDL_GetGamepads(&count);
     if (joysticks) {
         int i;
         for (i = 0; i < count && i < NK_GAMEPAD_MAX; i++) {
@@ -161,12 +165,13 @@ NK_API nk_bool nk_gamepad_sdl3_init(struct nk_gamepads* gamepads, void* user_dat
 }
 
 NK_API void nk_gamepad_sdl3_free(struct nk_gamepads* gamepads, void* user_data) {
+    int i;
     NK_UNUSED(user_data);
     if (!gamepads) {
         return;
     }
 
-    for (int i = 0; i < NK_GAMEPAD_MAX; i++) {
+    for (i = 0; i < NK_GAMEPAD_MAX; i++) {
         if (gamepads->gamepads[i].data != NULL) {
             SDL_CloseGamepad((SDL_Gamepad*)gamepads->gamepads[i].data);
             gamepads->gamepads[i].data = NULL;
@@ -203,15 +208,18 @@ SDL_GamepadButton nk_gamepad_sdl3_map_button(int button) {
 }
 
 NK_API void nk_gamepad_sdl3_update(struct nk_gamepads* gamepads, void* user_data) {
+    int num;
+    int i;
+    SDL_Gamepad* gamepad;
     NK_UNUSED(user_data);
-    for (int num = 0; num < NK_GAMEPAD_MAX; num++) {
+    for (num = 0; num < NK_GAMEPAD_MAX; num++) {
         if (gamepads->gamepads[num].data == NULL) {
             continue;
         }
 
-        SDL_Gamepad* gamepad = (SDL_Gamepad*)gamepads->gamepads[num].data;
+        gamepad = (SDL_Gamepad*)gamepads->gamepads[num].data;
 
-        // Check to make sure it's still attached.
+        /* Check to make sure it's still attached. */
         if (SDL_GetGamepadID(gamepad) == 0) {
             gamepads->gamepads[num].available = nk_false;
             SDL_CloseGamepad(gamepad);
@@ -219,13 +227,13 @@ NK_API void nk_gamepad_sdl3_update(struct nk_gamepads* gamepads, void* user_data
             continue;
         }
 
-        for (int i = NK_GAMEPAD_BUTTON_FIRST; i < NK_GAMEPAD_BUTTON_LAST; i++) {
+        for (i = NK_GAMEPAD_BUTTON_FIRST; i < NK_GAMEPAD_BUTTON_LAST; i++) {
             if (SDL_GetGamepadButton(gamepad, nk_gamepad_sdl3_map_button(i))) {
                 nk_gamepad_button(gamepads, num, (enum nk_gamepad_button)i, nk_true);
             }
         }
 
-        // Axes: SDL3 returns Sint16 in range -32768..32767 (sticks) or 0..32767 (triggers)
+        /* Axes: SDL3 returns Sint16 in range -32768..32767 (sticks) or 0..32767 (triggers) */
         nk_gamepad_axis(gamepads, num, NK_GAMEPAD_AXIS_LEFT_X, SDL_GetGamepadAxis(gamepad, SDL_GAMEPAD_AXIS_LEFTX) / 32767.0f);
         nk_gamepad_axis(gamepads, num, NK_GAMEPAD_AXIS_LEFT_Y, SDL_GetGamepadAxis(gamepad, SDL_GAMEPAD_AXIS_LEFTY) / 32767.0f);
         nk_gamepad_axis(gamepads, num, NK_GAMEPAD_AXIS_RIGHT_X, SDL_GetGamepadAxis(gamepad, SDL_GAMEPAD_AXIS_RIGHTX) / 32767.0f);
@@ -236,12 +244,13 @@ NK_API void nk_gamepad_sdl3_update(struct nk_gamepads* gamepads, void* user_data
 }
 
 NK_API const char* nk_gamepad_sdl3_name(struct nk_gamepads* gamepads, int num, void* user_data) {
+    const char* name;
     NK_UNUSED(user_data);
     if (gamepads->gamepads[num].data == NULL) {
         return NULL;
     }
 
-    const char* name = SDL_GetGamepadName((SDL_Gamepad*)gamepads->gamepads[num].data);
+    name = SDL_GetGamepadName((SDL_Gamepad*)gamepads->gamepads[num].data);
     if (name == NULL || name[0] == '\0') {
         return gamepads->gamepads[num].name;
     }
@@ -249,11 +258,13 @@ NK_API const char* nk_gamepad_sdl3_name(struct nk_gamepads* gamepads, int num, v
 }
 
 NK_API const char* nk_gamepad_sdl3_button_name(struct nk_gamepads* gamepads, enum nk_gamepad_button button, void* user_data) {
+    SDL_GamepadButton sdl_button;
     NK_UNUSED(user_data);
 
-    SDL_GamepadButton sdl_button = nk_gamepad_sdl3_map_button(button);
+    sdl_button = nk_gamepad_sdl3_map_button(button);
     if (sdl_button != SDL_GAMEPAD_BUTTON_INVALID && gamepads != NULL) {
-        for (int i = 0; i < NK_GAMEPAD_MAX; i++) {
+        int i;
+        for (i = 0; i < NK_GAMEPAD_MAX; i++) {
             if (gamepads->gamepads[i].data != NULL) {
                 SDL_GamepadButtonLabel label = SDL_GetGamepadButtonLabel(
                     (SDL_Gamepad*)gamepads->gamepads[i].data, sdl_button);
@@ -277,16 +288,15 @@ NK_API const char* nk_gamepad_sdl3_button_name(struct nk_gamepads* gamepads, enu
 }
 
 NK_API struct nk_gamepad_input_source nk_gamepad_sdl3_input_source(void* user_data) {
-    struct nk_gamepad_input_source source = {
-        .user_data = user_data,
-        .init = &nk_gamepad_sdl3_init,
-        .update = &nk_gamepad_sdl3_update,
-        .free = &nk_gamepad_sdl3_free,
-        .name = &nk_gamepad_sdl3_name,
-        .button_name = &nk_gamepad_sdl3_button_name,
-        .input_source_name = "SDL3",
-        .id = NK_GAMEPAD_INPUT_SOURCE_SDL3,
-    };
+    struct nk_gamepad_input_source source;
+    source.user_data = user_data;
+    source.init = &nk_gamepad_sdl3_init;
+    source.update = &nk_gamepad_sdl3_update;
+    source.free = &nk_gamepad_sdl3_free;
+    source.name = &nk_gamepad_sdl3_name;
+    source.button_name = &nk_gamepad_sdl3_button_name;
+    source.input_source_name = "SDL3";
+    source.id = NK_GAMEPAD_INPUT_SOURCE_SDL3;
     return source;
 }
 


### PR DESCRIPTION
Hoists for-loop counters and other mid-block declarations to the top of each function, converts `//` comments to `/* */`, and replaces designated struct initializers with member-by-member assignment — matching the style already used in the keyboard and mouse backends. Fixes #41