### PR TITLE
Fix mouse D-pad to use threshold comparison

### DIFF
--- a/nuklear_gamepad_mouse.h
+++ b/nuklear_gamepad_mouse.h
@@ -12,6 +12,14 @@
 #define NK_GAMEPAD_MOUSE_SENSITIVITY 12.0f
 #endif
 
+#ifndef NK_GAMEPAD_MOUSE_DPAD_THRESHOLD
+/**
+ * Axis magnitude at or beyond which D-pad buttons are considered pressed (0.0 to 1.0).
+ * Using a threshold instead of exact equality avoids fragility with future sensitivity scaling.
+ */
+#define NK_GAMEPAD_MOUSE_DPAD_THRESHOLD 0.999f
+#endif
+
 /**
  * Mouse mapping to gamepad buttons and axes.
  *
@@ -119,11 +127,11 @@ NK_API void nk_gamepad_mouse_update(struct nk_gamepads* gamepads, void* user_dat
     nk_gamepad_axis(gamepads, 0, NK_GAMEPAD_AXIS_LEFT_X, dx);
     nk_gamepad_axis(gamepads, 0, NK_GAMEPAD_AXIS_LEFT_Y, dy);
 
-    /* When axis reaches max, consider it a D-Pad press. */
-    nk_gamepad_button(gamepads, 0, NK_GAMEPAD_BUTTON_LEFT,  dx == -1.0f);
-    nk_gamepad_button(gamepads, 0, NK_GAMEPAD_BUTTON_RIGHT, dx ==  1.0f);
-    nk_gamepad_button(gamepads, 0, NK_GAMEPAD_BUTTON_UP,    dy == -1.0f);
-    nk_gamepad_button(gamepads, 0, NK_GAMEPAD_BUTTON_DOWN,  dy ==  1.0f);
+    /* When axis reaches threshold, consider it a D-Pad press. */
+    nk_gamepad_button(gamepads, 0, NK_GAMEPAD_BUTTON_LEFT,  dx <= -NK_GAMEPAD_MOUSE_DPAD_THRESHOLD);
+    nk_gamepad_button(gamepads, 0, NK_GAMEPAD_BUTTON_RIGHT, dx >=  NK_GAMEPAD_MOUSE_DPAD_THRESHOLD);
+    nk_gamepad_button(gamepads, 0, NK_GAMEPAD_BUTTON_UP,    dy <= -NK_GAMEPAD_MOUSE_DPAD_THRESHOLD);
+    nk_gamepad_button(gamepads, 0, NK_GAMEPAD_BUTTON_DOWN,  dy >=  NK_GAMEPAD_MOUSE_DPAD_THRESHOLD);
 
     /* Scroll maps to right stick axes */
     dx = mouse->scroll_delta.x / map->sensitivity;

--- a/test/nuklear_gamepad_test.c
+++ b/test/nuklear_gamepad_test.c
@@ -106,6 +106,53 @@ int main() {
     assert(strcmp(nk_gamepad_button_name(&gamepads, NK_GAMEPAD_BUTTON_UP), "Up") == 0);
     assert(strcmp(nk_gamepad_button_name(&gamepads, NK_GAMEPAD_BUTTON_A), "Z") == 0);
 
+    /* nk_gamepad_mouse D-pad threshold */
+    printf("nk_gamepad_mouse D-pad threshold\n");
+    {
+        struct nk_gamepad_mouse_map map;
+        int j;
+
+        /* Custom map: default sensitivity, no button bindings */
+        nk_zero(&map, sizeof(map));
+        map.sensitivity = NK_GAMEPAD_MOUSE_SENSITIVITY;
+        for (j = 0; j < NK_BUTTON_MAX; j++) {
+            map.buttons[j] = NK_GAMEPAD_BUTTON_INVALID;
+        }
+
+        /* Full positive x-delta triggers RIGHT only */
+        nk_gamepad_update(&gamepads);
+        gamepads.ctx->input.mouse.delta.x = map.sensitivity;
+        gamepads.ctx->input.mouse.delta.y = 0.0f;
+        nk_gamepad_mouse_update(&gamepads, &map);
+        assert(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_RIGHT) == nk_true);
+        assert(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_LEFT)  == nk_false);
+
+        /* Full negative x-delta triggers LEFT only */
+        nk_gamepad_update(&gamepads);
+        gamepads.ctx->input.mouse.delta.x = -map.sensitivity;
+        gamepads.ctx->input.mouse.delta.y = 0.0f;
+        nk_gamepad_mouse_update(&gamepads, &map);
+        assert(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_LEFT)  == nk_true);
+        assert(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_RIGHT) == nk_false);
+
+        /* Half deflection does not trigger D-pad */
+        nk_gamepad_update(&gamepads);
+        gamepads.ctx->input.mouse.delta.x = map.sensitivity * 0.5f;
+        gamepads.ctx->input.mouse.delta.y = 0.0f;
+        nk_gamepad_mouse_update(&gamepads, &map);
+        assert(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_RIGHT) == nk_false);
+        assert(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_LEFT)  == nk_false);
+
+        /* Different sensitivity: delta equal to sensitivity triggers */
+        map.sensitivity = 6.0f;
+        nk_gamepad_update(&gamepads);
+        gamepads.ctx->input.mouse.delta.x = 6.0f;
+        gamepads.ctx->input.mouse.delta.y = 6.0f;
+        nk_gamepad_mouse_update(&gamepads, &map);
+        assert(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_RIGHT) == nk_true);
+        assert(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_DOWN)  == nk_true);
+    }
+
     printf("nk_gamepad_free()\n");
     nk_gamepad_free(&gamepads);
 


### PR DESCRIPTION
Replaces exact float equality (`dx == 1.0f`) in the mouse D-pad detection with a configurable `NK_GAMEPAD_MOUSE_DPAD_THRESHOLD` (default `0.999f`) using `<=`/`>=`, and adds regression tests covering positive/negative deflection and multiple sensitivity values. Fixes #40