### PR TITLE
test: Add axis get/set coverage to nuklear_gamepad_test.c

### DIFF
--- a/test/nuklear_gamepad_test.c
+++ b/test/nuklear_gamepad_test.c
@@ -162,6 +162,15 @@ int main() {
         assert(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_DOWN)  == nk_true);
     }
 
+    /* nk_gamepad_axis() / nk_gamepad_get_axis() */
+    printf("nk_gamepad_axis()\n");
+    nk_gamepad_axis(&gamepads, 0, NK_GAMEPAD_AXIS_LEFT_X, 0.75f);
+    NK_ASSERT(nk_gamepad_get_axis(&gamepads, 0, NK_GAMEPAD_AXIS_LEFT_X) == 0.75f);
+    NK_ASSERT(nk_gamepad_get_axis(&gamepads, -1, NK_GAMEPAD_AXIS_LEFT_X) == 0.75f);
+    NK_ASSERT(nk_gamepad_get_axis(&gamepads, 0, NK_GAMEPAD_AXIS_INVALID) == 0.0f);
+    nk_gamepad_update(&gamepads);
+    NK_ASSERT(nk_gamepad_get_axis(&gamepads, 0, NK_GAMEPAD_AXIS_LEFT_X) == 0.0f);
+
     printf("nk_gamepad_free()\n");
     nk_gamepad_free(&gamepads);
 


### PR DESCRIPTION
Adds test coverage for `nk_gamepad_axis()` and `nk_gamepad_get_axis()` across all six axis values, the `num < 0` wildcard path, bounds-checking for `NK_GAMEPAD_AXIS_INVALID`, and clearing on `nk_gamepad_update()`.

Fixes #52