### PR TITLE
Add nk_gamepad_input_source_count() helper

### DIFF
--- a/nuklear_gamepad.h
+++ b/nuklear_gamepad.h
@@ -404,6 +404,13 @@ NK_API nk_bool nk_gamepad_set_input_source(struct nk_gamepads* gamepads, struct 
  */
 NK_API nk_gamepad_input_source_fn nk_gamepad_input_sources[];
 
+/**
+ * Returns the number of available compiled gamepad input sources.
+ *
+ * @return The count of entries in nk_gamepad_input_sources[], not counting the NULL terminator.
+ */
+NK_API int nk_gamepad_input_source_count(void);
+
 #ifdef __cplusplus
 }
 #endif
@@ -915,6 +922,12 @@ NK_API nk_bool nk_gamepad_set_input_source(struct nk_gamepads* gamepads, struct 
     NK_MEMCPY(gamepads, &new_gamepads, sizeof(struct nk_gamepads));
 
     return nk_true;
+}
+
+NK_API int nk_gamepad_input_source_count(void) {
+    int i = 0;
+    while (nk_gamepad_input_sources[i] != NULL) i++;
+    return i;
 }
 
 #ifdef __cplusplus

--- a/test/nuklear_gamepad_test.c
+++ b/test/nuklear_gamepad_test.c
@@ -37,6 +37,9 @@ int main() {
     printf("nk_gamepad_init()\n");
     nk_gamepad_init(&gamepads, &ctx, NULL);
 
+    printf("nk_gamepad_input_source_count()\n");
+    NK_ASSERT(nk_gamepad_input_source_count() >= 1);
+
     printf("nk_gamepad_count()\n");
     NK_ASSERT(nk_gamepad_count(&gamepads) == NK_GAMEPAD_MAX);
 


### PR DESCRIPTION
Adds `nk_gamepad_input_source_count()` which returns the number of entries in the NULL-terminated `nk_gamepad_input_sources[]` array, removing the need for callers to walk it manually.

Fixes #51