### PR TITLE
Add nk_gamepad_axis_name() to mirror nk_gamepad_button_name()

### DIFF
--- a/nuklear_gamepad.h
+++ b/nuklear_gamepad.h
@@ -328,6 +328,15 @@ NK_API nk_bool nk_gamepad_any_button_down(struct nk_gamepads* gamepads, int num,
 NK_API const char* nk_gamepad_button_name(struct nk_gamepads* gamepads, enum nk_gamepad_button button);
 
 /**
+ * Get the human-readable name of a gamepad axis.
+ *
+ * @param gamepads The associated gamepad system. Can be NULL to use built-in names.
+ * @param axis The axis to get the name for.
+ * @return The name of the axis, or NULL if the axis is invalid.
+ */
+NK_API const char* nk_gamepad_axis_name(struct nk_gamepads* gamepads, enum nk_gamepad_axis axis);
+
+/**
  * Invoke a button press or release event for the specified gamepad.
  *
  * @param gamepads The associated gamepad system.
@@ -865,6 +874,19 @@ NK_API const char* nk_gamepad_button_name(struct nk_gamepads* gamepads, enum nk_
         case NK_GAMEPAD_BUTTON_START: return "Start";
         case NK_GAMEPAD_BUTTON_GUIDE: return "Guide";
         default:                      return NULL;
+    }
+}
+
+NK_API const char* nk_gamepad_axis_name(struct nk_gamepads* gamepads, enum nk_gamepad_axis axis) {
+    (void)gamepads;
+    switch (axis) {
+        case NK_GAMEPAD_AXIS_LEFT_X:        return "Left Stick X";
+        case NK_GAMEPAD_AXIS_LEFT_Y:        return "Left Stick Y";
+        case NK_GAMEPAD_AXIS_RIGHT_X:       return "Right Stick X";
+        case NK_GAMEPAD_AXIS_RIGHT_Y:       return "Right Stick Y";
+        case NK_GAMEPAD_AXIS_LEFT_TRIGGER:  return "Left Trigger";
+        case NK_GAMEPAD_AXIS_RIGHT_TRIGGER: return "Right Trigger";
+        default:                            return NULL;
     }
 }
 

--- a/nuklear_gamepad.h
+++ b/nuklear_gamepad.h
@@ -119,6 +119,7 @@ typedef void (*nk_gamepad_update_fn)(struct nk_gamepads *gamepads, void* user_da
 typedef void (*nk_gamepad_free_fn)(struct nk_gamepads *gamepads, void* user_data);
 typedef const char *(*nk_gamepad_name_fn)(struct nk_gamepads *gamepads, int num, void* user_data);
 typedef const char *(*nk_gamepad_button_name_fn)(struct nk_gamepads *gamepads, enum nk_gamepad_button button, void* user_data);
+typedef const char *(*nk_gamepad_axis_name_fn)(struct nk_gamepads *gamepads, enum nk_gamepad_axis axis, void* user_data);
 
 /**
  * A function to retrieve an input source definition.
@@ -137,6 +138,7 @@ struct nk_gamepad_input_source {
     nk_gamepad_free_fn free;
     nk_gamepad_name_fn name; /* Callback to get the name of a plugged in controller. */
     nk_gamepad_button_name_fn button_name; /* Callback to get the name of a button. Falls back to built-in names if NULL. */
+    nk_gamepad_axis_name_fn axis_name; /* Callback to get the name of an axis. Falls back to built-in names if NULL. */
     const char* input_source_name; /* The human-readable name of the input source. */
     enum nk_gamepad_input_source_type id; /* A unique identifier of the input source. */
 };
@@ -883,7 +885,9 @@ NK_API const char* nk_gamepad_button_name(struct nk_gamepads* gamepads, enum nk_
 }
 
 NK_API const char* nk_gamepad_axis_name(struct nk_gamepads* gamepads, enum nk_gamepad_axis axis) {
-    (void)gamepads;
+    if (gamepads != NULL && gamepads->input_source.axis_name != NULL) {
+        return gamepads->input_source.axis_name(gamepads, axis, gamepads->input_source.user_data);
+    }
     switch (axis) {
         case NK_GAMEPAD_AXIS_LEFT_X:        return "Left Stick X";
         case NK_GAMEPAD_AXIS_LEFT_Y:        return "Left Stick Y";

--- a/nuklear_gamepad_glfw.h
+++ b/nuklear_gamepad_glfw.h
@@ -106,6 +106,7 @@ NK_API struct nk_gamepad_input_source nk_gamepad_glfw_input_source(void* user_da
     source.free = NULL;
     source.name = &nk_gamepad_glfw_name;
     source.button_name = NULL;
+    source.axis_name = NULL;
     source.input_source_name = "glfw";
     source.id = NK_GAMEPAD_INPUT_SOURCE_GLFW;
     return source;

--- a/nuklear_gamepad_keyboard.h
+++ b/nuklear_gamepad_keyboard.h
@@ -224,6 +224,7 @@ NK_API struct nk_gamepad_input_source nk_gamepad_keyboard_input_source(void* use
     source.free = NULL;
     source.name = &nk_gamepad_keyboard_name;
     source.button_name = &nk_gamepad_keyboard_button_name;
+    source.axis_name = NULL;
     source.input_source_name = "Keyboard";
     source.id = NK_GAMEPAD_INPUT_SOURCE_KEYBOARD;
     return source;

--- a/nuklear_gamepad_mouse.h
+++ b/nuklear_gamepad_mouse.h
@@ -220,6 +220,7 @@ NK_API struct nk_gamepad_input_source nk_gamepad_mouse_input_source(void* user_d
     source.free = NULL;
     source.name = &nk_gamepad_mouse_name;
     source.button_name = &nk_gamepad_mouse_button_name;
+    source.axis_name = NULL;
     source.input_source_name = "Mouse";
     source.id = NK_GAMEPAD_INPUT_SOURCE_MOUSE;
     return source;

--- a/nuklear_gamepad_none.h
+++ b/nuklear_gamepad_none.h
@@ -36,6 +36,7 @@ NK_API struct nk_gamepad_input_source nk_gamepad_none_input_source(void* user_da
     source.free = NULL;
     source.name = NULL;
     source.button_name = NULL;
+    source.axis_name = NULL;
     source.input_source_name = "None";
     source.id = NK_GAMEPAD_INPUT_SOURCE_NONE;
     return source;

--- a/nuklear_gamepad_pntr.h
+++ b/nuklear_gamepad_pntr.h
@@ -71,6 +71,7 @@ NK_API struct nk_gamepad_input_source nk_gamepad_pntr_input_source(void* user_da
         .free = NULL,
         .name = NULL,
         .button_name = NULL,
+        .axis_name = NULL,
         .input_source_name = "pntr",
         .id = NK_GAMEPAD_INPUT_SOURCE_PNTR,
     };

--- a/nuklear_gamepad_raylib.h
+++ b/nuklear_gamepad_raylib.h
@@ -92,6 +92,7 @@ NK_API struct nk_gamepad_input_source nk_gamepad_raylib_input_source(void* user_
     source.free = NULL;
     source.name = &nk_gamepad_raylib_name;
     source.button_name = NULL;
+    source.axis_name = NULL;
     source.input_source_name = "raylib";
     source.id = NK_GAMEPAD_INPUT_SOURCE_RAYLIB;
     return source;

--- a/nuklear_gamepad_sdl.h
+++ b/nuklear_gamepad_sdl.h
@@ -177,6 +177,7 @@ NK_API struct nk_gamepad_input_source nk_gamepad_sdl_input_source(void* user_dat
     source.free = &nk_gamepad_sdl_free;
     source.name = &nk_gamepad_sdl_name;
     source.button_name = NULL;
+    source.axis_name = NULL;
     source.input_source_name = "SDL";
     source.id = NK_GAMEPAD_INPUT_SOURCE_SDL;
     return source;

--- a/nuklear_gamepad_sdl3.h
+++ b/nuklear_gamepad_sdl3.h
@@ -295,6 +295,7 @@ NK_API struct nk_gamepad_input_source nk_gamepad_sdl3_input_source(void* user_da
     source.free = &nk_gamepad_sdl3_free;
     source.name = &nk_gamepad_sdl3_name;
     source.button_name = &nk_gamepad_sdl3_button_name;
+    source.axis_name = NULL;
     source.input_source_name = "SDL3";
     source.id = NK_GAMEPAD_INPUT_SOURCE_SDL3;
     return source;

--- a/test/nuklear_gamepad_test.c
+++ b/test/nuklear_gamepad_test.c
@@ -115,6 +115,12 @@ int main() {
     NK_ASSERT(strcmp(nk_gamepad_button_name(&gamepads, NK_GAMEPAD_BUTTON_UP), "Up") == 0);
     NK_ASSERT(strcmp(nk_gamepad_button_name(&gamepads, NK_GAMEPAD_BUTTON_A), "Z") == 0);
 
+    /* nk_gamepad_axis_name() */
+    NK_ASSERT(strcmp(nk_gamepad_axis_name(NULL, NK_GAMEPAD_AXIS_LEFT_X), "Left Stick X") == 0);
+    NK_ASSERT(strcmp(nk_gamepad_axis_name(NULL, NK_GAMEPAD_AXIS_RIGHT_TRIGGER), "Right Trigger") == 0);
+    NK_ASSERT(strcmp(nk_gamepad_axis_name(&gamepads, NK_GAMEPAD_AXIS_LEFT_Y), "Left Stick Y") == 0);
+    NK_ASSERT(nk_gamepad_axis_name(NULL, NK_GAMEPAD_AXIS_INVALID) == NULL);
+
     /* nk_gamepad_mouse D-pad threshold */
     printf("nk_gamepad_mouse D-pad threshold\n");
     {


### PR DESCRIPTION
Adds `nk_gamepad_axis_name()` returning human-readable names for all six axis values (e.g. `"Left Stick X"`, `"Right Trigger"`), mirroring the existing `nk_gamepad_button_name()` API. Returns NULL for invalid axes.

Fixes #50