### PR TITLE
Add NK_GAMEPAD_VERSION compile-time version macros

### DIFF
--- a/nuklear_gamepad.h
+++ b/nuklear_gamepad.h
@@ -27,6 +27,11 @@
 #ifndef NUKLEAR_GAMEPAD_H__
 #define NUKLEAR_GAMEPAD_H__
 
+#define NK_GAMEPAD_VERSION "1.0.2"
+#define NK_GAMEPAD_VERSION_MAJOR 1
+#define NK_GAMEPAD_VERSION_MINOR 0
+#define NK_GAMEPAD_VERSION_PATCH 2
+
 #ifndef NK_GAMEPAD_MAX
 /**
  * The maximum amount of gamepads that can be supported.

--- a/test/nuklear_gamepad_test.c
+++ b/test/nuklear_gamepad_test.c
@@ -28,9 +28,9 @@ int main() {
     printf("--------------------\n");
 
     /* NK_GAMEPAD_VERSION macros */
-    #if NK_GAMEPAD_VERSION_MAJOR >= 1
-    NK_ASSERT(NK_GAMEPAD_VERSION_MAJOR >= 1);
-    #endif
+    NK_ASSERT(NK_GAMEPAD_VERSION_MAJOR == 1);
+    NK_ASSERT(NK_GAMEPAD_VERSION_MINOR == 0);
+    NK_ASSERT(NK_GAMEPAD_VERSION_PATCH == 2);
     NK_ASSERT(strcmp(NK_GAMEPAD_VERSION, "1.0.2") == 0);
 
     /* NK_GAMEPAD_BUTTON is used with int flags, so we need it to be <32 */

--- a/test/nuklear_gamepad_test.c
+++ b/test/nuklear_gamepad_test.c
@@ -27,6 +27,12 @@ int main() {
     printf("nuklear_gamepad_test\n");
     printf("--------------------\n");
 
+    /* NK_GAMEPAD_VERSION macros */
+    #if NK_GAMEPAD_VERSION_MAJOR >= 1
+    NK_ASSERT(NK_GAMEPAD_VERSION_MAJOR >= 1);
+    #endif
+    NK_ASSERT(strcmp(NK_GAMEPAD_VERSION, "1.0.2") == 0);
+
     /* NK_GAMEPAD_BUTTON is used with int flags, so we need it to be <32 */
     NK_ASSERT(NK_GAMEPAD_BUTTON_LAST < (32 - 1));
 


### PR DESCRIPTION
Adds `NK_GAMEPAD_VERSION`, `NK_GAMEPAD_VERSION_MAJOR`, `NK_GAMEPAD_VERSION_MINOR`, and `NK_GAMEPAD_VERSION_PATCH` macros matching the `VERSION 1.0.2` declared in `CMakeLists.txt`, enabling compile-time version checks.

Fixes #49