### PR TITLE
keyboard: Add F1-F12 and Alt key names to button name function

### DIFF
--- a/nuklear_gamepad_keyboard.h
+++ b/nuklear_gamepad_keyboard.h
@@ -173,7 +173,19 @@ NK_API const char* nk_gamepad_keyboard_button_name(struct nk_gamepads* gamepads,
             case NK_KEY_COPY:      return "Copy";
             case NK_KEY_CUT:       return "Cut";
             case NK_KEY_PASTE:     return "Paste";
-            /* TODO: Add F1-F12, ALT */
+            case NK_KEY_F1:        return "F1";
+            case NK_KEY_F2:        return "F2";
+            case NK_KEY_F3:        return "F3";
+            case NK_KEY_F4:        return "F4";
+            case NK_KEY_F5:        return "F5";
+            case NK_KEY_F6:        return "F6";
+            case NK_KEY_F7:        return "F7";
+            case NK_KEY_F8:        return "F8";
+            case NK_KEY_F9:        return "F9";
+            case NK_KEY_F10:       return "F10";
+            case NK_KEY_F11:       return "F11";
+            case NK_KEY_F12:       return "F12";
+            case NK_KEY_ALT:       return "Alt";
             default: break;
         }
     }

--- a/test/nuklear_gamepad_test.c
+++ b/test/nuklear_gamepad_test.c
@@ -115,6 +115,19 @@ int main() {
     NK_ASSERT(strcmp(nk_gamepad_button_name(&gamepads, NK_GAMEPAD_BUTTON_UP), "Up") == 0);
     NK_ASSERT(strcmp(nk_gamepad_button_name(&gamepads, NK_GAMEPAD_BUTTON_A), "Z") == 0);
 
+    /* keyboard: F-key and Alt names */
+    {
+        struct nk_gamepad_keyboard_map fmap;
+        struct nk_gamepads kbd_gamepads;
+        nk_zero(&fmap, sizeof(fmap));
+        fmap.keys[NK_GAMEPAD_BUTTON_A] = NK_KEY_F5;
+        fmap.keys[NK_GAMEPAD_BUTTON_B] = NK_KEY_ALT;
+        nk_gamepad_init_with_source(&kbd_gamepads, &ctx, nk_gamepad_keyboard_input_source(&fmap));
+        NK_ASSERT(strcmp(nk_gamepad_button_name(&kbd_gamepads, NK_GAMEPAD_BUTTON_A), "F5") == 0);
+        NK_ASSERT(strcmp(nk_gamepad_button_name(&kbd_gamepads, NK_GAMEPAD_BUTTON_B), "Alt") == 0);
+        nk_gamepad_free(&kbd_gamepads);
+    }
+
     /* nk_gamepad_mouse D-pad threshold */
     printf("nk_gamepad_mouse D-pad threshold\n");
     {


### PR DESCRIPTION
Fills the `/* TODO: Add F1-F12, ALT */` in `nk_gamepad_keyboard_button_name()` — buttons mapped to F1–F12 or Alt now return their readable name instead of NULL.

Fixes #48