### PR TITLE
Harden controller name generation

### DIFF
--- a/nuklear_gamepad.h
+++ b/nuklear_gamepad.h
@@ -538,8 +538,45 @@ NK_API nk_bool nk_gamepad_init(struct nk_gamepads* gamepads, struct nk_context* 
     return nk_gamepad_init_with_source(gamepads, ctx, NK_GAMEPAD_DEFAULT_INPUT_SOURCE(user_data));
 }
 
+/**
+ * Writes the given non-negative number to the buffer as a string.
+ *
+ * Avoids nuklear's nk_itoa, which is not available when NK_GAMEPAD_IMPLEMENTATION
+ * is defined in a translation unit without NK_IMPLEMENTATION.
+ *
+ * @param buffer The buffer to write to, which must hold at least 12 characters.
+ * @param number The non-negative number to write.
+ *
+ * @return The length of the written string, excluding the NUL terminator.
+ *
+ * @internal
+ */
+NK_INTERN int nk_gamepad_int_to_string(char* buffer, int number) {
+    int length = 0;
+    int j;
+    char temp;
+
+    /* Write out the digits in reverse order. */
+    do {
+        buffer[length++] = (char)('0' + (number % 10));
+        number /= 10;
+    } while (number > 0);
+
+    /* Reverse the digits into place. */
+    for (j = 0; j < length / 2; j++) {
+        temp = buffer[j];
+        buffer[j] = buffer[length - 1 - j];
+        buffer[length - 1 - j] = temp;
+    }
+
+    buffer[length] = '\0';
+    return length;
+}
+
 NK_API nk_bool nk_gamepad_init_with_source(struct nk_gamepads* gamepads, struct nk_context* ctx, struct nk_gamepad_input_source input_source) {
     int i;
+    const char* name_prefix = NK_GAMEPAD_NAME_PREFIX;
+    int name_prefix_length = nk_strlen(NK_GAMEPAD_NAME_PREFIX);
     if (gamepads == NULL) {
         return nk_false;
     }
@@ -553,13 +590,26 @@ NK_API nk_bool nk_gamepad_init_with_source(struct nk_gamepads* gamepads, struct 
     for (i = 0; i < NK_GAMEPAD_MAX; i++) {
         /* Name */
         int j;
-        const char* name_prefix = NK_GAMEPAD_NAME_PREFIX;
-        for (j = 0; j < nk_strlen(name_prefix); j++) {
+        char number[12];
+        int number_length = nk_gamepad_int_to_string(number, i + 1);
+
+        /* Truncate the prefix so the # and NUL terminator always fit. */
+        int prefix_length = name_prefix_length;
+        if (prefix_length + number_length + 1 > NK_GAMEPAD_NAME_SIZE) {
+            prefix_length = NK_GAMEPAD_NAME_SIZE - number_length - 1;
+            if (prefix_length < 0) {
+                prefix_length = 0;
+            }
+        }
+        for (j = 0; j < prefix_length; j++) {
             gamepads->gamepads[i].name[j] = name_prefix[j];
         }
 
         /* Add the # of the controller to the name. */
-        nk_itoa(&gamepads->gamepads[i].name[j], (long)(i + 1));
+        for (j = 0; j < number_length && prefix_length + j + 1 < NK_GAMEPAD_NAME_SIZE; j++) {
+            gamepads->gamepads[i].name[prefix_length + j] = number[j];
+        }
+        gamepads->gamepads[i].name[prefix_length + j] = '\0';
     }
 
     /* Run the init() callback, or update() if it's not available. */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,22 @@ else()
     target_compile_options(nuklear_gamepad_test PRIVATE -Wall -Wextra -Wpedantic -UNDEBUG)
 endif()
 
+# nuklear_gamepad_test_prefix: Long NK_GAMEPAD_NAME_PREFIX
+add_executable(nuklear_gamepad_test_prefix nuklear_gamepad_test_prefix.c)
+
+# C99 Standard
+set_property(TARGET nuklear_gamepad_test_prefix PROPERTY C_STANDARD 90)
+set_property(TARGET nuklear_gamepad_test_prefix PROPERTY C_STANDARD_REQUIRED TRUE)
+
+# Strict Warnings and Errors
+if(MSVC)
+    target_compile_options(nuklear_gamepad_test_prefix PRIVATE /W4 /WX /UNDEBUG)
+else()
+    target_compile_options(nuklear_gamepad_test_prefix PRIVATE -Wall -Wextra -Wpedantic -UNDEBUG)
+endif()
+
 # Set up the test
 list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
 set(CTEST_OUTPUT_ON_FAILURE TRUE)
 add_test(NAME nuklear_gamepad_test COMMAND nuklear_gamepad_test)
+add_test(NAME nuklear_gamepad_test_prefix COMMAND nuklear_gamepad_test_prefix)

--- a/test/nuklear_gamepad_test.c
+++ b/test/nuklear_gamepad_test.c
@@ -78,6 +78,14 @@ int main() {
         NK_ASSERT(controller_name == NULL);
     }
 
+    /* Make sure the default controller names are generated correctly. */
+    printf("default controller names\n");
+    {
+        NK_ASSERT(strcmp(gamepads.gamepads[1].name, "Controller 2") == 0);
+        NK_ASSERT(strcmp(gamepads.gamepads[2].name, "Controller 3") == 0);
+        NK_ASSERT((int)strlen(gamepads.gamepads[1].name) < NK_GAMEPAD_NAME_SIZE);
+    }
+
     /* Update the state of the gamepads. */
     printf("nk_gamepad_update()\n");
     nk_gamepad_update(&gamepads);

--- a/test/nuklear_gamepad_test_prefix.c
+++ b/test/nuklear_gamepad_test_prefix.c
@@ -1,0 +1,72 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define NK_ASSERT(cond) \
+    do { \
+        if (!(cond)) { \
+            fprintf(stderr, "Assertion failed: %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+            exit(1); \
+        } \
+    } while (0)
+
+#define NK_INCLUDE_DEFAULT_ALLOCATOR
+#define NK_IMPLEMENTATION
+#include "../vendor/nuklear/nuklear.h"
+
+/* Use a name prefix that is longer than NK_GAMEPAD_NAME_SIZE. */
+#define NK_GAMEPAD_NAME_PREFIX "An Extremely Long Gamepad Controller Name Prefix "
+
+#define NK_GAMEPAD_IMPLEMENTATION
+#include "../nuklear_gamepad.h"
+
+int main() {
+    struct nk_context ctx;
+    struct nk_gamepads gamepads;
+    int i;
+    const char* prefix = NK_GAMEPAD_NAME_PREFIX;
+    NK_UNUSED(nk_inv_sqrt); /* Small fix for unused function */
+    printf("nuklear_gamepad_test_prefix\n");
+    printf("---------------------------\n");
+
+    /* The prefix must be longer than the name buffer for this test. */
+    NK_ASSERT((int)strlen(prefix) >= NK_GAMEPAD_NAME_SIZE);
+
+    /* Initialize the Nuklear context */
+    nk_init_default(&ctx, 0);
+
+    /* Set up the gamepads. */
+    printf("nk_gamepad_init()\n");
+    NK_ASSERT(nk_gamepad_init(&gamepads, &ctx, NULL) == nk_true);
+
+    /* Make sure the long prefix was truncated without overflowing the name. */
+    printf("truncated controller names\n");
+    for (i = 0; i < NK_GAMEPAD_MAX; i++) {
+        char expected[NK_GAMEPAD_NAME_SIZE];
+        char number[12];
+        int number_length;
+        int prefix_length;
+
+        /* Build the expected name: truncated prefix, followed by the #. */
+        sprintf(number, "%d", i + 1);
+        number_length = (int)strlen(number);
+        prefix_length = NK_GAMEPAD_NAME_SIZE - number_length - 1;
+        memcpy(expected, prefix, (size_t)prefix_length);
+        memcpy(expected + prefix_length, number, (size_t)number_length + 1);
+
+        NK_ASSERT(gamepads.gamepads[i].name[NK_GAMEPAD_NAME_SIZE - 1] == '\0');
+        NK_ASSERT((int)strlen(gamepads.gamepads[i].name) == NK_GAMEPAD_NAME_SIZE - 1);
+        NK_ASSERT(strcmp(gamepads.gamepads[i].name, expected) == 0);
+    }
+
+    printf("nk_gamepad_free()\n");
+    nk_gamepad_free(&gamepads);
+
+    nk_free(&ctx);
+
+    printf("---------------------------\n");
+    printf("nuklear_gamepad_test_prefix: Tests passed!\n");
+
+    return 0;
+}


### PR DESCRIPTION
Bounds the default-name copy in nk_gamepad_init_with_source so an overridden NK_GAMEPAD_NAME_PREFIX can no longer overflow the name buffer, hoists the strlen out of the loop, and replaces the private nk_itoa with a local helper. Adds tests for default names and a long prefix. Fixes #76