### PR TITLE
Validate button values in query functions

### DIFF
--- a/nuklear_gamepad.h
+++ b/nuklear_gamepad.h
@@ -596,7 +596,10 @@ NK_API void nk_gamepad_free(struct nk_gamepads* gamepads) {
 }
 
 NK_API void nk_gamepad_button(struct nk_gamepads* gamepads, int num, enum nk_gamepad_button button, nk_bool down) {
-    if (gamepads == NULL || num < 0 || num >= NK_GAMEPAD_MAX || gamepads->gamepads[num].available == nk_false) {
+    if (gamepads == NULL || num < 0 || num >= NK_GAMEPAD_MAX || button < 0 || button >= NK_GAMEPAD_BUTTON_LAST) {
+        return;
+    }
+    if (gamepads->gamepads[num].available == nk_false) {
         return;
     }
 
@@ -668,7 +671,7 @@ NK_API void nk_gamepad_update(struct nk_gamepads* gamepads) {
 }
 
 NK_API nk_bool nk_gamepad_is_button_down(struct nk_gamepads* gamepads, int num, enum nk_gamepad_button button) {
-    if (gamepads == NULL) {
+    if (gamepads == NULL || button < 0 || button >= NK_GAMEPAD_BUTTON_LAST) {
         return nk_false;
     }
 
@@ -689,7 +692,7 @@ NK_API nk_bool nk_gamepad_is_button_down(struct nk_gamepads* gamepads, int num, 
 }
 
 NK_API nk_bool nk_gamepad_is_button_pressed(struct nk_gamepads* gamepads, int num, enum nk_gamepad_button button) {
-    if (gamepads == NULL) {
+    if (gamepads == NULL || button < 0 || button >= NK_GAMEPAD_BUTTON_LAST) {
         return nk_false;
     }
 
@@ -711,7 +714,7 @@ NK_API nk_bool nk_gamepad_is_button_pressed(struct nk_gamepads* gamepads, int nu
 }
 
 NK_API nk_bool nk_gamepad_is_button_released(struct nk_gamepads* gamepads, int num, enum nk_gamepad_button button) {
-    if (gamepads == NULL) {
+    if (gamepads == NULL || button < 0 || button >= NK_GAMEPAD_BUTTON_LAST) {
         return nk_false;
     }
 

--- a/test/nuklear_gamepad_test.c
+++ b/test/nuklear_gamepad_test.c
@@ -94,6 +94,21 @@ int main() {
     NK_ASSERT(nk_gamepad_is_button_down(&gamepads, -1, NK_GAMEPAD_BUTTON_A) == nk_true);
     NK_ASSERT(nk_gamepad_is_button_down(&gamepads, -1, NK_GAMEPAD_BUTTON_B) == nk_false);
 
+    /* Invalid button values are safely rejected. */
+    printf("invalid button values\n");
+    {
+        nk_gamepad_button(&gamepads, 0, NK_GAMEPAD_BUTTON_INVALID, nk_true);
+        nk_gamepad_button(&gamepads, 0, NK_GAMEPAD_BUTTON_LAST, nk_true);
+        NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_INVALID) == nk_false);
+        NK_ASSERT(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_LAST) == nk_false);
+        NK_ASSERT(nk_gamepad_is_button_down(&gamepads, -1, NK_GAMEPAD_BUTTON_INVALID) == nk_false);
+        NK_ASSERT(nk_gamepad_is_button_pressed(&gamepads, 0, NK_GAMEPAD_BUTTON_INVALID) == nk_false);
+        NK_ASSERT(nk_gamepad_is_button_pressed(&gamepads, 0, NK_GAMEPAD_BUTTON_LAST) == nk_false);
+        NK_ASSERT(nk_gamepad_is_button_pressed(&gamepads, -1, NK_GAMEPAD_BUTTON_LAST) == nk_false);
+        NK_ASSERT(nk_gamepad_is_button_released(&gamepads, 0, NK_GAMEPAD_BUTTON_INVALID) == nk_false);
+        NK_ASSERT(nk_gamepad_is_button_released(&gamepads, 0, NK_GAMEPAD_BUTTON_LAST) == nk_false);
+    }
+
     /* nk_gamepad_any_button_pressed() */
     {
         int num = 9999;


### PR DESCRIPTION
Adds range checks to the four button query functions so out-of-range values like NK_GAMEPAD_BUTTON_INVALID return nk_false instead of triggering a negative shift (UB), mirroring nk_gamepad_axis validation. The get_axis -1 behavior already matches its doc comment, so it is unchanged. Fixes #75