### PR TITLE
Clamp backend update loops to NK_GAMEPAD_MAX

### DIFF
--- a/nuklear_gamepad.h
+++ b/nuklear_gamepad.h
@@ -35,6 +35,8 @@
 #ifndef NK_GAMEPAD_MAX
 /**
  * The maximum amount of gamepads that can be supported.
+ *
+ * Define this before including nuklear_gamepad.h to change the amount.
  */
 #define NK_GAMEPAD_MAX 4
 #endif

--- a/nuklear_gamepad_glfw.h
+++ b/nuklear_gamepad_glfw.h
@@ -1,12 +1,6 @@
 #ifndef NUKLEAR_GAMEPAD_GLFW_H__
 #define NUKLEAR_GAMEPAD_GLFW_H__
 
-#if !defined(NK_GAMEPAD_MAX) && defined(GLFW_JOYSTICK_LAST)
-#define NK_GAMEPAD_MAX GLFW_JOYSTICK_LAST
-#elif !defined(NK_GAMEPAD_MAX)
-#define NK_GAMEPAD_MAX 4
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -58,7 +52,7 @@ void nk_gamepad_glfw_update(struct nk_gamepads* gamepads, void* user_data) {
         return;
     }
 
-    for (num = 0; num < NK_GAMEPAD_MAX; num++) {
+    for (num = 0; num < NK_GAMEPAD_MAX && num <= GLFW_JOYSTICK_LAST; num++) {
         /* Make sure it's available. */
         if (glfwJoystickIsGamepad(num) == GLFW_FALSE) {
             gamepads->gamepads[num].available = nk_false;

--- a/nuklear_gamepad_keyboard.h
+++ b/nuklear_gamepad_keyboard.h
@@ -1,10 +1,6 @@
 #ifndef NUKLEAR_GAMEPAD_KEYBOARD_H__
 #define NUKLEAR_GAMEPAD_KEYBOARD_H__
 
-#ifndef NK_GAMEPAD_MAX
-#define NK_GAMEPAD_MAX 1
-#endif
-
 /**
  * Keyboard mapping to gamepad buttons.
  *

--- a/nuklear_gamepad_mouse.h
+++ b/nuklear_gamepad_mouse.h
@@ -1,10 +1,6 @@
 #ifndef NUKLEAR_GAMEPAD_MOUSE_H__
 #define NUKLEAR_GAMEPAD_MOUSE_H__
 
-#ifndef NK_GAMEPAD_MAX
-#define NK_GAMEPAD_MAX 1
-#endif
-
 #ifndef NK_GAMEPAD_MOUSE_SENSITIVITY
 /**
  * Default mouse sensitivity: Pixels of delta per frame to reach full axis.

--- a/nuklear_gamepad_none.h
+++ b/nuklear_gamepad_none.h
@@ -1,10 +1,6 @@
 #ifndef NUKLEAR_GAMEPAD_NONE_H__
 #define NUKLEAR_GAMEPAD_NONE_H__
 
-#if !defined(NK_GAMEPAD_MAX)
-#define NK_GAMEPAD_MAX 0
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/nuklear_gamepad_pntr.h
+++ b/nuklear_gamepad_pntr.h
@@ -1,11 +1,6 @@
 #ifndef NUKLEAR_GAMEPAD_PNTR_H__
 #define NUKLEAR_GAMEPAD_PNTR_H__
 
-#ifndef NK_GAMEPAD_MAX
-#define NK_GAMEPAD_MAX PNTR_APP_MAX_GAMEPADS
-#endif
-
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -58,7 +53,7 @@ void nk_gamepad_pntr_update(struct nk_gamepads* gamepads, void* user_data) {
 
     app = (pntr_app*)gamepads->input_source.user_data;
 
-    for (int num = 0; num < PNTR_APP_MAX_GAMEPADS; num++) {
+    for (int num = 0; num < NK_GAMEPAD_MAX && num < PNTR_APP_MAX_GAMEPADS; num++) {
         // pntr has no gamepad connect/disconnect events, so detect availability
         // via button presses (state transitions). Once detected, the gamepad
         // stays available since there is no way to detect disconnection.


### PR DESCRIPTION
Removes the dead per-backend NK_GAMEPAD_MAX overrides (they ran after the default was already defined) and bounds the pntr and GLFW update loops to NK_GAMEPAD_MAX, fixing the pntr out-of-bounds write when PNTR_APP_MAX_GAMEPADS exceeds 4 and the GLFW_JOYSTICK_LAST off-by-one. NK_GAMEPAD_MAX stays user-overridable before include. Fixes #73