### PR TITLE
Add extern to nk_gamepad_input_sources

### DIFF
--- a/nuklear_gamepad.h
+++ b/nuklear_gamepad.h
@@ -422,7 +422,7 @@ NK_API nk_bool nk_gamepad_set_input_source(struct nk_gamepads* gamepads, struct 
 /**
  * An null-terminated array of the available compiled gamepad input sources.
  */
-NK_API nk_gamepad_input_source_fn nk_gamepad_input_sources[];
+extern nk_gamepad_input_source_fn nk_gamepad_input_sources[];
 
 /**
  * Returns the number of available compiled gamepad input sources.


### PR DESCRIPTION
Declares nk_gamepad_input_sources with plain extern so the header no longer emits a tentative definition per translation unit; plain extern (rather than NK_API extern) avoids a duplicate storage-class error since NK_API already expands to extern by default, and matches the definition in the implementation section. The failure reproduces when NK_API is overridden (empty or DLL export) or NK_PRIVATE is set; verified two-TU C link and C++ compile in both configurations. Fixes #72