### PR TITLE
Mouse backend: detection guard and sensitivity zero-guard

### DIFF
--- a/nuklear_gamepad.h
+++ b/nuklear_gamepad.h
@@ -450,6 +450,7 @@ NK_API int nk_gamepad_input_source_count(void);
     !defined(NK_GAMEPAD_RAYLIB) && \
     !defined(NK_GAMEPAD_PNTR) && \
     !defined(NK_GAMEPAD_KEYBOARD) && \
+    !defined(NK_GAMEPAD_MOUSE) && \
     !defined(NK_GAMEPAD_NONE)
     #if defined(NK_SDL_RENDERER_IMPLEMENTATION) || defined(NK_SDL_GL2_IMPLEMENTATION) || defined(NK_SDL_GL3_IMPLEMENTATION) || defined(NK_SDL_GLES2_IMPLEMENTATION)
         #define NK_GAMEPAD_SDL

--- a/nuklear_gamepad_mouse.h
+++ b/nuklear_gamepad_mouse.h
@@ -97,7 +97,7 @@ NK_API void nk_gamepad_mouse_update(struct nk_gamepads* gamepads, void* user_dat
     int i;
     struct nk_gamepad_mouse_map* map;
     struct nk_mouse* mouse;
-    float dx, dy;
+    float dx, dy, sensitivity;
 
     if (gamepads == NULL || gamepads->ctx == NULL) {
         return;
@@ -105,6 +105,9 @@ NK_API void nk_gamepad_mouse_update(struct nk_gamepads* gamepads, void* user_dat
 
     map = (user_data == NULL) ? &nk_gamepad_mouse_map_default : (struct nk_gamepad_mouse_map*)user_data;
     mouse = &gamepads->ctx->input.mouse;
+
+    /* A zero-initialized user map has no sensitivity set; fall back to the default. */
+    sensitivity = (map->sensitivity == 0.0f) ? NK_GAMEPAD_MOUSE_SENSITIVITY : map->sensitivity;
 
     /* Mouse buttons */
     for (i = 0; i < NK_BUTTON_MAX; i++) {
@@ -114,8 +117,8 @@ NK_API void nk_gamepad_mouse_update(struct nk_gamepads* gamepads, void* user_dat
     }
 
     /* Mouse delta maps to left stick axes */
-    dx = mouse->delta.x / map->sensitivity;
-    dy = mouse->delta.y / map->sensitivity;
+    dx = mouse->delta.x / sensitivity;
+    dy = mouse->delta.y / sensitivity;
     if (dx >  1.0f) dx =  1.0f;
     if (dx < -1.0f) dx = -1.0f;
     if (dy >  1.0f) dy =  1.0f;
@@ -130,8 +133,8 @@ NK_API void nk_gamepad_mouse_update(struct nk_gamepads* gamepads, void* user_dat
     nk_gamepad_button(gamepads, 0, NK_GAMEPAD_BUTTON_DOWN,  dy >=  NK_GAMEPAD_MOUSE_DPAD_THRESHOLD);
 
     /* Scroll maps to right stick axes */
-    dx = mouse->scroll_delta.x / map->sensitivity;
-    dy = mouse->scroll_delta.y / map->sensitivity;
+    dx = mouse->scroll_delta.x / sensitivity;
+    dy = mouse->scroll_delta.y / sensitivity;
     if (dx >  1.0f) dx =  1.0f;
     if (dx < -1.0f) dx = -1.0f;
     if (dy >  1.0f) dy =  1.0f;

--- a/test/nuklear_gamepad_test.c
+++ b/test/nuklear_gamepad_test.c
@@ -205,6 +205,25 @@ int main() {
         assert(nk_gamepad_is_button_down(&gamepads, 0, NK_GAMEPAD_BUTTON_DOWN)  == nk_true);
     }
 
+    /* nk_gamepad_mouse zero-initialized map falls back to default sensitivity */
+    printf("nk_gamepad_mouse zero-initialized map\n");
+    {
+        struct nk_gamepad_mouse_map zmap;
+        float ax, ay;
+        nk_zero(&zmap, sizeof(zmap));
+
+        nk_gamepad_update(&gamepads);
+        gamepads.ctx->input.mouse.delta.x = NK_GAMEPAD_MOUSE_SENSITIVITY * 0.5f;
+        gamepads.ctx->input.mouse.delta.y = -NK_GAMEPAD_MOUSE_SENSITIVITY;
+        nk_gamepad_mouse_update(&gamepads, &zmap);
+        ax = nk_gamepad_get_axis(&gamepads, 0, NK_GAMEPAD_AXIS_LEFT_X);
+        ay = nk_gamepad_get_axis(&gamepads, 0, NK_GAMEPAD_AXIS_LEFT_Y);
+        /* ax == ax rejects NaN without requiring math.h */
+        assert(ax == ax && ay == ay);
+        assert(ax == 0.5f);
+        assert(ay == -1.0f);
+    }
+
     /* nk_gamepad_axis() / nk_gamepad_get_axis() */
     printf("nk_gamepad_axis()\n");
     nk_gamepad_axis(&gamepads, 0, NK_GAMEPAD_AXIS_LEFT_X, 0.75f);


### PR DESCRIPTION
Adds NK_GAMEPAD_MOUSE to the backend auto-detection guard and falls back to NK_GAMEPAD_MOUSE_SENSITIVITY when a user map has zero sensitivity, with a test covering a zero-initialized map. Fixes #77